### PR TITLE
Add nanoarrow support

### DIFF
--- a/pyo3-arrow/README.md
+++ b/pyo3-arrow/README.md
@@ -96,35 +96,51 @@ For example, `PySchema` and `PyField` both use the `__arrow_c_schema__` mechanis
 
 #### Using `arro3.core`
 
-`arro3.core` is a very minimal Python Arrow implementation, designed to be lightweight (<1MB) and relatively stable. In comparison, pyarrow is on the order of ~100MB.
+[`arro3.core`](https://github.com/kylebarron/arro3) is a very minimal Python Arrow implementation, designed to be lightweight (<1MB) and relatively stable. In comparison, pyarrow is on the order of ~100MB.
 
 You must depend on the `arro3-core` Python package; then you can use the `to_arro3` method of each exported Arrow object to pass the data into an `arro3.core` class.
 
 | Rust struct           | arro3 class                    |
 | --------------------- | ------------------------------ |
-| `PyArray`             | `arro3.core.Array`             |
-| `PyChunkedArray`      | `arro3.core.ChunkedArray`      |
 | `PyField`             | `arro3.core.Field`             |
 | `PySchema`            | `arro3.core.Schema`            |
-| `PyTable`             | `arro3.core.Table`             |
+| `PyArray`             | `arro3.core.Array`             |
 | `PyRecordBatch`       | `arro3.core.RecordBatch`       |
+| `PyChunkedArray`      | `arro3.core.ChunkedArray`      |
+| `PyTable`             | `arro3.core.Table`             |
 | `PyRecordBatchReader` | `arro3.core.RecordBatchReader` |
 
 #### Using `pyarrow`
 
-`pyarrow`, the canonical Python Arrow implementation, is a very large dependency. It's roughly 100MB in size on its own, plus 35MB more for its hard depdnency on numpy. However, `numpy` is very likely already in the user environment, and `pyarrow` is quite common as well, so requiring a `pyarrow` dependency may not be a problem.
+[`pyarrow`](https://arrow.apache.org/docs/python/index.html), the canonical Python Arrow implementation, is a very large dependency. It's roughly 100MB in size on its own, plus 35MB more for its hard dependency on numpy. However, `numpy` is very likely already in the user environment, and `pyarrow` is quite common as well, so requiring a `pyarrow` dependency may not be a problem.
 
 In this case, you must depend on `pyarrow` and you can use the `to_pyarrow` method of Python structs to return data to Python. This requires `pyarrow>=14` (`pyarrow>=15` is required to return `PyRecordBatchReader`).
 
 | Rust struct           | pyarrow class               |
 | --------------------- | --------------------------- |
-| `PyArray`             | `pyarrow.Array`             |
-| `PyChunkedArray`      | `pyarrow.ChunkedArray`      |
 | `PyField`             | `pyarrow.Field`             |
 | `PySchema`            | `pyarrow.Schema`            |
-| `PyTable`             | `pyarrow.Table`             |
+| `PyArray`             | `pyarrow.Array`             |
 | `PyRecordBatch`       | `pyarrow.RecordBatch`       |
+| `PyChunkedArray`      | `pyarrow.ChunkedArray`      |
+| `PyTable`             | `pyarrow.Table`             |
 | `PyRecordBatchReader` | `pyarrow.RecordBatchReader` |
+
+#### Using `nanoarrow`
+
+[`nanoarrow`](https://arrow.apache.org/nanoarrow/latest/index.html) is an alternative Python library for working with Arrow data. It's similar in goals to arro3, but is written in C instead of Rust. Additionally, it has a smaller type system than `pyarrow` or `arro3`, with logical arrays and record batches both represented by the `nanoarrow.Array` class.
+
+In this case, you must depend on `nanoarrow` and you can use the `to_nanoarrow` method of Python structs to return data to Python.
+
+| Rust struct           | nanoarrow class         |
+| --------------------- | ----------------------- |
+| `PyField`             | `nanoarrow.Schema`      |
+| `PySchema`            | `nanoarrow.Schema`      |
+| `PyArray`             | `nanoarrow.Array`       |
+| `PyRecordBatch`       | `nanoarrow.Array`       |
+| `PyChunkedArray`      | `nanoarrow.ArrayStream` |
+| `PyTable`             | `nanoarrow.ArrayStream` |
+| `PyRecordBatchReader` | `nanoarrow.ArrayStream` |
 
 ## Why not use arrow-rs's Python integration?
 

--- a/pyo3-arrow/src/array.rs
+++ b/pyo3-arrow/src/array.rs
@@ -10,6 +10,7 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 
 use crate::error::PyArrowResult;
 use crate::ffi::from_python::utils::import_array_pycapsules;
+use crate::ffi::to_python::nanoarrow::to_nanoarrow_array;
 use crate::interop::numpy::to_numpy::to_numpy;
 
 /// A Python-facing Arrow array.
@@ -52,6 +53,11 @@ impl PyArray {
             self.__arrow_c_array__(py, None)?,
         )?;
         Ok(core_obj.to_object(py))
+    }
+
+    /// Export this to a Python `nanoarrow.Array`.
+    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+        to_nanoarrow_array(py, &self.__arrow_c_array__(py, None)?)
     }
 
     /// Export to a pyarrow.Array

--- a/pyo3-arrow/src/chunked.rs
+++ b/pyo3-arrow/src/chunked.rs
@@ -12,6 +12,7 @@ use crate::ffi::from_python::ffi_stream::ArrowArrayStreamReader;
 use crate::ffi::from_python::utils::import_stream_pycapsule;
 use crate::ffi::to_python::chunked::ArrayIterator;
 use crate::ffi::to_python::ffi_stream::new_stream;
+use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 use crate::interop::numpy::to_numpy::chunked_to_numpy;
 
 /// A Python-facing Arrow chunked array.
@@ -50,6 +51,11 @@ impl PyChunkedArray {
                 PyTuple::new_bound(py, vec![self.__arrow_c_stream__(py, None)?]),
             )?;
         Ok(core_obj.to_object(py))
+    }
+
+    /// Export this to a Python `nanoarrow.ArrayStream`.
+    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+        to_nanoarrow_array_stream(py, &self.__arrow_c_stream__(py, None)?)
     }
 
     /// Export to a pyarrow.ChunkedArray

--- a/pyo3-arrow/src/ffi/to_python/mod.rs
+++ b/pyo3-arrow/src/ffi/to_python/mod.rs
@@ -1,2 +1,3 @@
 pub mod chunked;
 pub mod ffi_stream;
+pub mod nanoarrow;

--- a/pyo3-arrow/src/ffi/to_python/nanoarrow.rs
+++ b/pyo3-arrow/src/ffi/to_python/nanoarrow.rs
@@ -1,0 +1,25 @@
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple};
+
+pub fn to_nanoarrow_schema(py: Python, capsule: &Bound<'_, PyCapsule>) -> PyResult<PyObject> {
+    let na_mod = py.import_bound(intern!(py, "nanoarrow"))?;
+    let pyarrow_obj = na_mod
+        .getattr(intern!(py, "Schema"))?
+        .call1(PyTuple::new_bound(py, vec![capsule]))?;
+    Ok(pyarrow_obj.to_object(py))
+}
+
+pub fn to_nanoarrow_array(py: Python, capsules: &Bound<'_, PyTuple>) -> PyResult<PyObject> {
+    let na_mod = py.import_bound(intern!(py, "nanoarrow"))?;
+    let pyarrow_obj = na_mod.getattr(intern!(py, "Array"))?.call1(capsules)?;
+    Ok(pyarrow_obj.to_object(py))
+}
+
+pub fn to_nanoarrow_array_stream(py: Python, capsule: &Bound<'_, PyCapsule>) -> PyResult<PyObject> {
+    let na_mod = py.import_bound(intern!(py, "nanoarrow"))?;
+    let pyarrow_obj = na_mod
+        .getattr(intern!(py, "ArrayStream"))?
+        .call1(PyTuple::new_bound(py, vec![capsule]))?;
+    Ok(pyarrow_obj.to_object(py))
+}

--- a/pyo3-arrow/src/field.rs
+++ b/pyo3-arrow/src/field.rs
@@ -10,6 +10,7 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 
 use crate::error::PyArrowResult;
 use crate::ffi::from_python::utils::import_schema_pycapsule;
+use crate::ffi::to_python::nanoarrow::to_nanoarrow_schema;
 
 /// A Python-facing Arrow field.
 ///
@@ -23,7 +24,7 @@ impl PyField {
     }
 
     /// Export this to a Python `arro3.core.Field`.
-    pub fn to_arro3(&self, py: Python) -> PyArrowResult<PyObject> {
+    pub fn to_arro3(&self, py: Python) -> PyResult<PyObject> {
         let arro3_mod = py.import_bound(intern!(py, "arro3.core"))?;
         let core_obj = arro3_mod.getattr(intern!(py, "Field"))?.call_method1(
             intern!(py, "from_arrow_pycapsule"),
@@ -32,10 +33,15 @@ impl PyField {
         Ok(core_obj.to_object(py))
     }
 
+    /// Export this to a Python `nanoarrow.Schema`.
+    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+        to_nanoarrow_schema(py, &self.__arrow_c_schema__(py)?)
+    }
+
     /// Export to a pyarrow.Field
     ///
     /// Requires pyarrow >=14
-    pub fn to_pyarrow(self, py: Python) -> PyArrowResult<PyObject> {
+    pub fn to_pyarrow(self, py: Python) -> PyResult<PyObject> {
         let pyarrow_mod = py.import_bound(intern!(py, "pyarrow"))?;
         let pyarrow_obj = pyarrow_mod
             .getattr(intern!(py, "field"))?

--- a/pyo3-arrow/src/input.rs
+++ b/pyo3-arrow/src/input.rs
@@ -1,3 +1,8 @@
+//! Special input types to allow broader user input.
+//!
+//! These types tend to be used for unknown user input, and thus do not exist for return types,
+//! where the exact type is known.
+
 use crate::{PyRecordBatch, PyRecordBatchReader};
 
 /// An enum over [PyRecordBatch] and [PyRecordBatchReader], used when a function accepts either

--- a/pyo3-arrow/src/record_batch.rs
+++ b/pyo3-arrow/src/record_batch.rs
@@ -12,6 +12,7 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 
 use crate::error::PyArrowResult;
 use crate::ffi::from_python::utils::import_array_pycapsules;
+use crate::ffi::to_python::nanoarrow::to_nanoarrow_array;
 
 /// A Python-facing Arrow record batch.
 ///
@@ -35,6 +36,11 @@ impl PyRecordBatch {
                 self.__arrow_c_array__(py, None)?,
             )?;
         Ok(core_obj.to_object(py))
+    }
+
+    /// Export this to a Python `nanoarrow.Array`.
+    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+        to_nanoarrow_array(py, &self.__arrow_c_array__(py, None)?)
     }
 
     /// Export to a pyarrow.RecordBatch

--- a/pyo3-arrow/src/record_batch_reader.rs
+++ b/pyo3-arrow/src/record_batch_reader.rs
@@ -10,6 +10,7 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 
 use crate::error::PyArrowResult;
 use crate::ffi::from_python::utils::import_stream_pycapsule;
+use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 use crate::PyTable;
 
 /// A Python-facing Arrow record batch reader.
@@ -74,6 +75,11 @@ impl PyRecordBatchReader {
                 PyTuple::new_bound(py, vec![self.__arrow_c_stream__(py, None)?]),
             )?;
         Ok(core_obj.to_object(py))
+    }
+
+    /// Export this to a Python `nanoarrow.ArrayStream`.
+    pub fn to_nanoarrow(&mut self, py: Python) -> PyResult<PyObject> {
+        to_nanoarrow_array_stream(py, &self.__arrow_c_stream__(py, None)?)
     }
 
     /// Export to a pyarrow.RecordBatchReader

--- a/pyo3-arrow/src/schema.rs
+++ b/pyo3-arrow/src/schema.rs
@@ -10,6 +10,7 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 
 use crate::error::PyArrowResult;
 use crate::ffi::from_python::utils::import_schema_pycapsule;
+use crate::ffi::to_python::nanoarrow::to_nanoarrow_schema;
 
 /// A Python-facing Arrow schema.
 ///
@@ -30,6 +31,11 @@ impl PySchema {
             PyTuple::new_bound(py, vec![self.__arrow_c_schema__(py)?]),
         )?;
         Ok(core_obj.to_object(py))
+    }
+
+    /// Export this to a Python `nanoarrow.Schema`.
+    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+        to_nanoarrow_schema(py, &self.__arrow_c_schema__(py)?)
     }
 
     /// Export to a pyarrow.Schema

--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -12,6 +12,7 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 
 use crate::error::PyArrowResult;
 use crate::ffi::from_python::utils::import_stream_pycapsule;
+use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 
 /// A Python-facing Arrow table.
 ///
@@ -44,6 +45,11 @@ impl PyTable {
             PyTuple::new_bound(py, vec![self.__arrow_c_stream__(py, None)?]),
         )?;
         Ok(core_obj.to_object(py))
+    }
+
+    /// Export this to a Python `nanoarrow.ArrayStream`.
+    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+        to_nanoarrow_array_stream(py, &self.__arrow_c_stream__(py, None)?)
     }
 
     /// Export to a pyarrow.Table


### PR DESCRIPTION
Adds support to `pyo3-arrow` for returning Arrow data from Rust as nanoarrow objects.

cc @paleolimbot 