### PR TITLE
Support both array and stream arrow objects in data constructors

### DIFF
--- a/arro3-core/python/arro3/core/_core.pyi
+++ b/arro3-core/python/arro3/core/_core.pyi
@@ -24,7 +24,7 @@ class Array:
     def __len__(self) -> int: ...
     def __repr__(self) -> str: ...
     @classmethod
-    def from_arrow(cls, input: ArrowArrayExportable) -> Array:
+    def from_arrow(cls, input: ArrowArrayExportable | ArrowStreamExportable) -> Array:
         """
         Construct this object from an existing Arrow object.
 
@@ -75,7 +75,9 @@ class ArrayReader:
     def __arrow_c_stream__(self, requested_schema: object | None = None) -> object: ...
     def __repr__(self) -> str: ...
     @classmethod
-    def from_arrow(cls, input: ArrowStreamExportable) -> ArrayReader: ...
+    def from_arrow(
+        cls, input: ArrowArrayExportable | ArrowStreamExportable
+    ) -> ArrayReader: ...
     @classmethod
     def from_arrow_pycapsule(cls, capsule) -> ArrayReader:
         """Construct this object from a bare Arrow PyCapsule"""
@@ -103,7 +105,9 @@ class ChunkedArray:
     def __len__(self) -> int: ...
     def __repr__(self) -> str: ...
     @classmethod
-    def from_arrow(cls, input: ArrowStreamExportable) -> ChunkedArray: ...
+    def from_arrow(
+        cls, input: ArrowArrayExportable | ArrowStreamExportable
+    ) -> ChunkedArray: ...
     @classmethod
     def from_arrow_pycapsule(cls, capsule) -> ChunkedArray:
         """Construct this object from a bare Arrow PyCapsule"""
@@ -630,7 +634,9 @@ class RecordBatch:
             New RecordBatch
         """
     @classmethod
-    def from_arrow(cls, input: ArrowArrayExportable) -> RecordBatch: ...
+    def from_arrow(
+        cls, input: ArrowArrayExportable | ArrowStreamExportable
+    ) -> RecordBatch: ...
     @classmethod
     def from_arrow_pycapsule(cls, schema_capsule, array_capsule) -> RecordBatch:
         """Construct this object from bare Arrow PyCapsules"""
@@ -720,7 +726,9 @@ class RecordBatchReader:
     def __arrow_c_stream__(self, requested_schema: object | None = None) -> object: ...
     def __repr__(self) -> str: ...
     @classmethod
-    def from_arrow(cls, input: ArrowStreamExportable) -> RecordBatchReader: ...
+    def from_arrow(
+        cls, input: ArrowArrayExportable | ArrowStreamExportable
+    ) -> RecordBatchReader: ...
     @classmethod
     def from_arrow_pycapsule(cls, capsule) -> RecordBatchReader:
         """Construct this object from a bare Arrow PyCapsule"""
@@ -963,7 +971,7 @@ class Table:
             new table
         """
     @classmethod
-    def from_arrow(cls, input: ArrowStreamExportable) -> Table:
+    def from_arrow(cls, input: ArrowArrayExportable | ArrowStreamExportable) -> Table:
         """
         Construct this object from an existing Arrow object.
 

--- a/pyo3-arrow/src/array_reader.rs
+++ b/pyo3-arrow/src/array_reader.rs
@@ -12,6 +12,7 @@ use crate::ffi::from_python::utils::import_stream_pycapsule;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 use crate::ffi::to_python::to_stream_pycapsule;
 use crate::ffi::{ArrayIterator, ArrayReader};
+use crate::input::AnyArray;
 use crate::{PyArray, PyChunkedArray, PyField};
 
 /// A Python-facing Arrow array reader.
@@ -136,8 +137,9 @@ impl PyArrayReader {
     /// It can be called on anything that exports the Arrow stream interface
     /// (`__arrow_c_stream__`), such as a `Table` or `ArrayReader`.
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: &Bound<PyAny>) -> PyResult<Self> {
-        input.extract()
+    pub fn from_arrow(_cls: &Bound<PyType>, input: AnyArray) -> PyArrowResult<Self> {
+        let reader = input.into_reader()?;
+        Ok(Self::new(reader))
     }
 
     /// Construct this object from a bare Arrow PyCapsule.

--- a/pyo3-arrow/src/chunked.rs
+++ b/pyo3-arrow/src/chunked.rs
@@ -15,6 +15,7 @@ use crate::ffi::from_python::utils::import_stream_pycapsule;
 use crate::ffi::to_python::chunked::ArrayIterator;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 use crate::ffi::to_python::to_stream_pycapsule;
+use crate::input::AnyArray;
 use crate::interop::numpy::to_numpy::chunked_to_numpy;
 use crate::{PyArray, PyDataType};
 
@@ -287,8 +288,8 @@ impl PyChunkedArray {
     /// It can be called on anything that exports the Arrow stream interface
     /// (`__arrow_c_stream__`). All batches will be materialized in memory.
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: &Bound<PyAny>) -> PyResult<Self> {
-        input.extract()
+    pub fn from_arrow(_cls: &Bound<PyType>, input: AnyArray) -> PyArrowResult<Self> {
+        input.into_chunked_array()
     }
 
     /// Construct this object from a bare Arrow PyCapsule

--- a/pyo3-arrow/src/datatypes.rs
+++ b/pyo3-arrow/src/datatypes.rs
@@ -131,8 +131,8 @@ impl PyDataType {
     /// It can be called on anything that exports the Arrow schema interface
     /// (`__arrow_c_schema__`).
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: &Bound<PyAny>) -> PyResult<Self> {
-        input.extract()
+    pub fn from_arrow(_cls: &Bound<PyType>, input: Self) -> Self {
+        input
     }
 
     /// Construct this object from a bare Arrow PyCapsule

--- a/pyo3-arrow/src/field.rs
+++ b/pyo3-arrow/src/field.rs
@@ -131,8 +131,8 @@ impl PyField {
     /// It can be called on anything that exports the Arrow schema interface
     /// (`__arrow_c_schema__`).
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: &Bound<PyAny>) -> PyResult<Self> {
-        input.extract()
+    pub fn from_arrow(_cls: &Bound<PyType>, input: Self) -> Self {
+        input
     }
 
     /// Construct this object from a bare Arrow PyCapsule

--- a/pyo3-arrow/src/record_batch_reader.rs
+++ b/pyo3-arrow/src/record_batch_reader.rs
@@ -13,6 +13,7 @@ use crate::ffi::from_python::utils::import_stream_pycapsule;
 use crate::ffi::to_python::chunked::ArrayIterator;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 use crate::ffi::to_python::to_stream_pycapsule;
+use crate::input::AnyRecordBatch;
 use crate::schema::display_schema;
 use crate::{PyRecordBatch, PySchema, PyTable};
 
@@ -153,8 +154,9 @@ impl PyRecordBatchReader {
     /// It can be called on anything that exports the Arrow stream interface
     /// (`__arrow_c_stream__`), such as a `Table` or `RecordBatchReader`.
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: &Bound<PyAny>) -> PyResult<Self> {
-        input.extract()
+    pub fn from_arrow(_cls: &Bound<PyType>, input: AnyRecordBatch) -> PyArrowResult<Self> {
+        let reader = input.into_reader()?;
+        Ok(Self::new(reader))
     }
 
     /// Construct this object from a bare Arrow PyCapsule.

--- a/pyo3-arrow/src/schema.rs
+++ b/pyo3-arrow/src/schema.rs
@@ -136,8 +136,8 @@ impl PySchema {
     }
 
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: &Bound<PyAny>) -> PyResult<Self> {
-        input.extract()
+    pub fn from_arrow(_cls: &Bound<PyType>, input: Self) -> Self {
+        input
     }
 
     #[classmethod]

--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -17,7 +17,9 @@ use crate::ffi::from_python::utils::import_stream_pycapsule;
 use crate::ffi::to_python::chunked::ArrayIterator;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 use crate::ffi::to_python::to_stream_pycapsule;
-use crate::input::{AnyArray, FieldIndexInput, MetadataInput, NameOrField, SelectIndices};
+use crate::input::{
+    AnyArray, AnyRecordBatch, FieldIndexInput, MetadataInput, NameOrField, SelectIndices,
+};
 use crate::schema::display_schema;
 use crate::{PyChunkedArray, PyField, PyRecordBatch, PyRecordBatchReader, PySchema};
 
@@ -117,8 +119,8 @@ impl PyTable {
     }
 
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: &Bound<PyAny>) -> PyResult<Self> {
-        input.extract()
+    pub fn from_arrow(_cls: &Bound<PyType>, input: AnyRecordBatch) -> PyArrowResult<Self> {
+        input.into_table()
     }
 
     #[classmethod]


### PR DESCRIPTION
Closes https://github.com/kylebarron/arro3/issues/80. This supports both `__arrow_c_array__` and `__arrow_c_stream__` in all data constructors. This concatenates stream input for `Array` and `RecordBatch`. It creates a single internal chunk or batch for array input to `Table` and `ChunkedArray`.