### PR TITLE
Don't distribute sdist

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -121,26 +121,26 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}-${{ matrix.module }}
           path: dist
 
-  sdist:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        module:
-          - arro3-core
-          - arro3-compute
-          - arro3-io
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build sdist
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
-      - name: Upload sdist
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-sdist-${{ matrix.module }}
-          path: dist
+  # sdist:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       module:
+  #         - arro3-core
+  #         - arro3-compute
+  #         - arro3-io
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Build sdist
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         command: sdist
+  #         args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
+  #     - name: Upload sdist
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-sdist-${{ matrix.module }}
+  #         path: dist
 
   release:
     runs-on: ubuntu-latest
@@ -158,7 +158,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [linux, windows, macos, sdist]
+    needs: [linux, windows, macos]
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The sdist is currently broken because it excludes the top-level `Cargo.toml`, so you can't actually build a wheel from the sdist. For now we'll just avoid distributing it.

I was able to include the top-level `Cargo.toml` by adding `includes` in `pyproject.toml` in the maturin section, but then I hit another error, and it's not worth debugging for now.