### PR TITLE
Improved rust docs and method visibility

### DIFF
--- a/arro3-core/python/arro3/core/_core.pyi
+++ b/arro3-core/python/arro3/core/_core.pyi
@@ -10,6 +10,7 @@ from .types import (
 
 class Array:
     """An Arrow Array."""
+
     def __init__(self, obj: Sequence[Any], /, type: ArrowSchemaExportable) -> None:
         """Create arro3.core.Array instance from a sequence of Python objects.
 
@@ -109,8 +110,8 @@ class ArrayReader:
         This dunder method should not be called directly, but enables zero-copy data
         transfer to other Python libraries that understand Arrow memory.
 
-        For example, you can call [`pyarrow.table()`][pyarrow.table] to convert this
-        ArrayReader to a pyarrow table, without copying memory.
+        For example, you can call [`pyarrow.chunked_array()`][pyarrow.chunked_array] to
+        convert this ArrayReader to a pyarrow ChunkedArray, without copying memory.
         """
     def __iter__(self) -> ArrayReader: ...
     def __next__(self) -> Array: ...

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,9 @@ plugins:
         python:
           paths: [arro3-compute/python, arro3-core/python, arro3-io/python]
           options:
+            # We set allow_inspection: false to ensure that all docstrings come
+            # from the pyi files, not the Rust-facing doc comments.
+            allow_inspection: false
             docstring_section_style: list
             docstring_style: google
             line_length: 80

--- a/pyo3-arrow/src/datatypes.rs
+++ b/pyo3-arrow/src/datatypes.rs
@@ -29,15 +29,18 @@ impl<'a> FromPyObject<'a> for PyTimeUnit {
     }
 }
 
+/// A Python-facing wrapper around [DataType].
 #[derive(PartialEq, Eq, Debug)]
 #[pyclass(module = "arro3.core._core", name = "DataType", subclass)]
 pub struct PyDataType(DataType);
 
 impl PyDataType {
+    /// Construct a new PyDataType around a [DataType].
     pub fn new(data_type: DataType) -> Self {
         Self(data_type)
     }
 
+    /// Consume this and return its inner part.
     pub fn into_inner(self) -> DataType {
         self.0
     }
@@ -104,28 +107,25 @@ impl Display for PyDataType {
 
 #[pymethods]
 impl PyDataType {
-    pub fn __arrow_c_schema__<'py>(
-        &'py self,
-        py: Python<'py>,
-    ) -> PyArrowResult<Bound<'py, PyCapsule>> {
+    fn __arrow_c_schema__<'py>(&'py self, py: Python<'py>) -> PyArrowResult<Bound<'py, PyCapsule>> {
         to_schema_pycapsule(py, &self.0)
     }
 
-    pub fn __eq__(&self, other: PyDataType) -> bool {
+    fn __eq__(&self, other: PyDataType) -> bool {
         self.equals(other, false)
     }
 
-    pub fn __repr__(&self) -> String {
+    fn __repr__(&self) -> String {
         self.to_string()
     }
 
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: Self) -> Self {
+    fn from_arrow(_cls: &Bound<PyType>, input: Self) -> Self {
         input
     }
 
     #[classmethod]
-    pub fn from_arrow_pycapsule(
+    pub(crate) fn from_arrow_pycapsule(
         _cls: &Bound<PyType>,
         capsule: &Bound<PyCapsule>,
     ) -> PyResult<Self> {
@@ -136,7 +136,7 @@ impl PyDataType {
     }
 
     #[getter]
-    pub fn bit_width(&self) -> Option<usize> {
+    fn bit_width(&self) -> Option<usize> {
         self.0.primitive_width()
     }
 

--- a/pyo3-arrow/src/error.rs
+++ b/pyo3-arrow/src/error.rs
@@ -1,9 +1,14 @@
+//! Contains the [`PyArrowError`], the Error returned by most fallible functions in this crate.
+
 use pyo3::exceptions::{PyException, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::PyDowncastError;
 
+/// The Error variants returned by this crate.
 pub enum PyArrowError {
+    /// A wrapped [arrow::error::ArrowError]
     ArrowError(arrow::error::ArrowError),
+    /// A wrapped [PyErr]
     PyErr(PyErr),
 }
 
@@ -49,4 +54,5 @@ impl From<PyErr> for PyArrowError {
     }
 }
 
+/// A type wrapper around `Result<T, PyArrowError>`.
 pub type PyArrowResult<T> = Result<T, PyArrowError>;

--- a/pyo3-arrow/src/ffi/mod.rs
+++ b/pyo3-arrow/src/ffi/mod.rs
@@ -1,6 +1,7 @@
+//! Utilities for managing Arrow FFI between Python and Rust.
+
 pub(crate) mod from_python;
 pub(crate) mod to_python;
 
 pub use to_python::chunked::{ArrayIterator, ArrayReader};
 pub use to_python::{to_array_pycapsules, to_schema_pycapsule, to_stream_pycapsule};
-// pub use

--- a/pyo3-arrow/src/ffi/to_python/chunked.rs
+++ b/pyo3-arrow/src/ffi/to_python/chunked.rs
@@ -8,8 +8,8 @@ use arrow_array::ArrayRef;
 pub trait ArrayReader: Iterator<Item = Result<ArrayRef, ArrowError>> {
     /// Returns the field of this `ArrayReader`.
     ///
-    /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
-    /// reader should have the same schema as returned from this method.
+    /// Implementation of this trait should guarantee that all `ArrayRef`'s returned by this
+    /// reader should have the same field as returned from this method.
     fn field(&self) -> FieldRef;
 }
 

--- a/pyo3-arrow/src/ffi/to_python/utils.rs
+++ b/pyo3-arrow/src/ffi/to_python/utils.rs
@@ -43,7 +43,8 @@ pub fn to_array_pycapsules<'py>(
     Ok(tuple)
 }
 
-/// Export an [`ArrayIterator`] to a PyCapsule holding an Arrow C Stream pointer.
+/// Export an [`ArrayIterator`][crate::ffi::ArrayIterator] to a PyCapsule holding an Arrow C Stream
+/// pointer.
 pub fn to_stream_pycapsule<'py>(
     py: Python<'py>,
     array_reader: Box<dyn ArrayReader + Send>,

--- a/pyo3-arrow/src/lib.rs
+++ b/pyo3-arrow/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
 
 mod array;
 mod array_reader;

--- a/pyo3-arrow/src/record_batch.rs
+++ b/pyo3-arrow/src/record_batch.rs
@@ -19,15 +19,20 @@ use crate::input::{AnyRecordBatch, FieldIndexInput, MetadataInput, NameOrField, 
 use crate::schema::display_schema;
 use crate::{PyArray, PyField, PySchema};
 
+/// A Python-facing Arrow record batch.
+///
+/// This is a wrapper around a [RecordBatch].
 #[pyclass(module = "arro3.core._core", name = "RecordBatch", subclass)]
 #[derive(Debug)]
 pub struct PyRecordBatch(RecordBatch);
 
 impl PyRecordBatch {
+    /// Construct a new PyRecordBatch from a [RecordBatch].
     pub fn new(batch: RecordBatch) -> Self {
         Self(batch)
     }
 
+    /// Consume this, returning its internal [RecordBatch].
     pub fn into_inner(self) -> RecordBatch {
         self.0
     }
@@ -91,7 +96,7 @@ impl Display for PyRecordBatch {
 impl PyRecordBatch {
     #[new]
     #[pyo3(signature = (data, *, metadata=None))]
-    pub fn init(
+    fn init(
         py: Python,
         data: &Bound<PyAny>,
         metadata: Option<MetadataInput>,
@@ -109,7 +114,7 @@ impl PyRecordBatch {
     }
 
     #[allow(unused_variables)]
-    pub fn __arrow_c_array__<'py>(
+    fn __arrow_c_array__<'py>(
         &'py self,
         py: Python<'py>,
         requested_schema: Option<Bound<PyCapsule>>,
@@ -119,7 +124,7 @@ impl PyRecordBatch {
         to_array_pycapsules(py, field.into(), &array, requested_schema)
     }
 
-    pub fn __eq__(&self, other: &PyRecordBatch) -> bool {
+    fn __eq__(&self, other: &PyRecordBatch) -> bool {
         self.0 == other.0
     }
 
@@ -127,13 +132,13 @@ impl PyRecordBatch {
         self.column(py, key)
     }
 
-    pub fn __repr__(&self) -> String {
+    fn __repr__(&self) -> String {
         self.to_string()
     }
 
     #[classmethod]
     #[pyo3(signature = (arrays, *, schema))]
-    pub fn from_arrays(
+    fn from_arrays(
         _cls: &Bound<PyType>,
         arrays: Vec<PyArray>,
         schema: PySchema,
@@ -153,7 +158,7 @@ impl PyRecordBatch {
 
     #[classmethod]
     #[pyo3(signature = (mapping, *, metadata=None))]
-    pub fn from_pydict(
+    fn from_pydict(
         _cls: &Bound<PyType>,
         mapping: IndexMap<String, PyArray>,
         metadata: Option<MetadataInput>,
@@ -172,7 +177,7 @@ impl PyRecordBatch {
     }
 
     #[classmethod]
-    pub fn from_struct_array(_cls: &Bound<PyType>, struct_array: PyArray) -> PyArrowResult<Self> {
+    fn from_struct_array(_cls: &Bound<PyType>, struct_array: PyArray) -> PyArrowResult<Self> {
         let (array, field) = struct_array.into_inner();
         match field.data_type() {
             DataType::Struct(fields) => {
@@ -187,7 +192,7 @@ impl PyRecordBatch {
     }
 
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: AnyRecordBatch) -> PyArrowResult<Self> {
+    fn from_arrow(_cls: &Bound<PyType>, input: AnyRecordBatch) -> PyArrowResult<Self> {
         match input {
             AnyRecordBatch::RecordBatch(rb) => Ok(rb),
             AnyRecordBatch::Stream(stream) => {
@@ -199,7 +204,7 @@ impl PyRecordBatch {
     }
 
     #[classmethod]
-    pub fn from_arrow_pycapsule(
+    pub(crate) fn from_arrow_pycapsule(
         _cls: &Bound<PyType>,
         schema_capsule: &Bound<PyCapsule>,
         array_capsule: &Bound<PyCapsule>,
@@ -229,7 +234,7 @@ impl PyRecordBatch {
         }
     }
 
-    pub fn add_column(
+    fn add_column(
         &self,
         py: Python,
         i: usize,
@@ -247,7 +252,7 @@ impl PyRecordBatch {
         Ok(PyRecordBatch::new(new_rb).to_arro3(py)?)
     }
 
-    pub fn append_column(
+    fn append_column(
         &self,
         py: Python,
         field: NameOrField,
@@ -264,7 +269,7 @@ impl PyRecordBatch {
         Ok(PyRecordBatch::new(new_rb).to_arro3(py)?)
     }
 
-    pub fn column(&self, py: Python, i: FieldIndexInput) -> PyResult<PyObject> {
+    fn column(&self, py: Python, i: FieldIndexInput) -> PyResult<PyObject> {
         let column_index = i.into_position(self.0.schema_ref())?;
         let field = self.0.schema().field(column_index).clone();
         let array = self.0.column(column_index).clone();
@@ -272,7 +277,7 @@ impl PyRecordBatch {
     }
 
     #[getter]
-    pub fn column_names(&self) -> Vec<String> {
+    fn column_names(&self) -> Vec<String> {
         self.0
             .schema()
             .fields()
@@ -282,17 +287,17 @@ impl PyRecordBatch {
     }
 
     #[getter]
-    pub fn columns(&self, py: Python) -> PyResult<Vec<PyObject>> {
+    fn columns(&self, py: Python) -> PyResult<Vec<PyObject>> {
         (0..self.num_columns())
             .map(|i| self.column(py, FieldIndexInput::Position(i)))
             .collect()
     }
 
-    pub fn equals(&self, other: PyRecordBatch) -> bool {
+    fn equals(&self, other: PyRecordBatch) -> bool {
         self.0 == other.0
     }
 
-    pub fn field(&self, py: Python, i: FieldIndexInput) -> PyResult<PyObject> {
+    fn field(&self, py: Python, i: FieldIndexInput) -> PyResult<PyObject> {
         let schema_ref = self.0.schema_ref();
         let field = schema_ref.field(i.into_position(schema_ref)?);
         PyField::new(field.clone().into()).to_arro3(py)
@@ -304,33 +309,33 @@ impl PyRecordBatch {
     }
 
     #[getter]
-    pub fn num_columns(&self) -> usize {
+    fn num_columns(&self) -> usize {
         self.0.num_columns()
     }
 
     #[getter]
-    pub fn num_rows(&self) -> usize {
+    fn num_rows(&self) -> usize {
         self.0.num_rows()
     }
 
-    pub fn remove_column(&self, py: Python, i: usize) -> PyResult<PyObject> {
+    fn remove_column(&self, py: Python, i: usize) -> PyResult<PyObject> {
         let mut rb = self.0.clone();
         rb.remove_column(i);
         PyRecordBatch::new(rb).to_arro3(py)
     }
 
     #[getter]
-    pub fn schema(&self, py: Python) -> PyResult<PyObject> {
+    fn schema(&self, py: Python) -> PyResult<PyObject> {
         PySchema::new(self.0.schema()).to_arro3(py)
     }
 
-    pub fn select(&self, py: Python, columns: SelectIndices) -> PyArrowResult<PyObject> {
+    fn select(&self, py: Python, columns: SelectIndices) -> PyArrowResult<PyObject> {
         let positions = columns.into_positions(self.0.schema_ref().fields())?;
         let new_rb = self.0.project(&positions)?;
         Ok(PyRecordBatch::new(new_rb).to_arro3(py)?)
     }
 
-    pub fn set_column(
+    fn set_column(
         &self,
         py: Python,
         i: usize,
@@ -349,12 +354,12 @@ impl PyRecordBatch {
     }
 
     #[getter]
-    pub fn shape(&self) -> (usize, usize) {
+    fn shape(&self) -> (usize, usize) {
         (self.num_rows(), self.num_columns())
     }
 
     #[pyo3(signature = (offset=0, length=None))]
-    pub fn slice(&self, py: Python, offset: usize, length: Option<usize>) -> PyResult<PyObject> {
+    fn slice(&self, py: Python, offset: usize, length: Option<usize>) -> PyResult<PyObject> {
         let length = length.unwrap_or_else(|| self.num_rows() - offset);
         PyRecordBatch::new(self.0.slice(offset, length)).to_arro3(py)
     }
@@ -364,14 +369,14 @@ impl PyRecordBatch {
         Ok(PyRecordBatch::new(new_batch).to_arro3(py)?)
     }
 
-    pub fn to_struct_array(&self, py: Python) -> PyArrowResult<PyObject> {
+    fn to_struct_array(&self, py: Python) -> PyArrowResult<PyObject> {
         let struct_array: StructArray = self.0.clone().into();
         let field = Field::new_struct("", self.0.schema_ref().fields().clone(), false)
             .with_metadata(self.0.schema_ref().metadata.clone());
         Ok(PyArray::new(Arc::new(struct_array), field.into()).to_arro3(py)?)
     }
 
-    pub fn with_schema(&self, py: Python, schema: PySchema) -> PyArrowResult<PyObject> {
+    fn with_schema(&self, py: Python, schema: PySchema) -> PyArrowResult<PyObject> {
         let new_schema = schema.into_inner();
         let new_batch = RecordBatch::try_new(new_schema.clone(), self.0.columns().to_vec())?;
         Ok(PyRecordBatch::new(new_batch).to_arro3(py)?)

--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -24,6 +24,9 @@ use crate::schema::display_schema;
 use crate::utils::schema_equals;
 use crate::{PyChunkedArray, PyField, PyRecordBatch, PyRecordBatchReader, PySchema};
 
+/// A Python-facing Arrow table.
+///
+/// This is a wrapper around a [SchemaRef] and a `Vec` of [RecordBatch].
 #[pyclass(module = "arro3.core._core", name = "Table", subclass)]
 #[derive(Debug)]
 pub struct PyTable {
@@ -32,20 +35,24 @@ pub struct PyTable {
 }
 
 impl PyTable {
-    pub fn new(batches: Vec<RecordBatch>, schema: SchemaRef) -> Self {
-        assert!(
-            batches
-                .iter()
-                .all(|rb| schema_equals(rb.schema_ref(), &schema)),
-            "All batches must have same schema"
-        );
-        Self { schema, batches }
+    /// Create a new table from batches and a schema.
+    pub fn try_new(batches: Vec<RecordBatch>, schema: SchemaRef) -> PyResult<Self> {
+        if !batches
+            .iter()
+            .all(|rb| schema_equals(rb.schema_ref(), &schema))
+        {
+            return Err(PyTypeError::new_err("All batches must have same schema"));
+        }
+
+        Ok(Self { schema, batches })
     }
 
+    /// Access the underlying batches
     pub fn batches(&self) -> &[RecordBatch] {
         &self.batches
     }
 
+    /// Consume this and return its internal batches and schema.
     pub fn into_inner(self) -> (Vec<RecordBatch>, SchemaRef) {
         (self.batches, self.schema)
     }
@@ -88,7 +95,7 @@ impl Display for PyTable {
 #[pymethods]
 impl PyTable {
     #[allow(unused_variables)]
-    pub fn __arrow_c_stream__<'py>(
+    fn __arrow_c_stream__<'py>(
         &'py self,
         py: Python<'py>,
         requested_schema: Option<Bound<PyCapsule>>,
@@ -105,7 +112,7 @@ impl PyTable {
         to_stream_pycapsule(py, array_reader, requested_schema)
     }
 
-    pub fn __eq__(&self, other: &PyTable) -> bool {
+    fn __eq__(&self, other: &PyTable) -> bool {
         self.batches == other.batches && self.schema == other.schema
     }
 
@@ -113,21 +120,21 @@ impl PyTable {
         self.column(py, key)
     }
 
-    pub fn __len__(&self) -> usize {
+    fn __len__(&self) -> usize {
         self.batches.iter().fold(0, |acc, x| acc + x.num_rows())
     }
 
-    pub fn __repr__(&self) -> String {
+    fn __repr__(&self) -> String {
         self.to_string()
     }
 
     #[classmethod]
-    pub fn from_arrow(_cls: &Bound<PyType>, input: AnyRecordBatch) -> PyArrowResult<Self> {
+    fn from_arrow(_cls: &Bound<PyType>, input: AnyRecordBatch) -> PyArrowResult<Self> {
         input.into_table()
     }
 
     #[classmethod]
-    pub fn from_arrow_pycapsule(
+    pub(crate) fn from_arrow_pycapsule(
         _cls: &Bound<PyType>,
         capsule: &Bound<PyCapsule>,
     ) -> PyResult<Self> {
@@ -142,12 +149,12 @@ impl PyTable {
             batches.push(batch);
         }
 
-        Ok(Self::new(batches, schema))
+        Self::try_new(batches, schema)
     }
 
     #[classmethod]
     #[pyo3(signature = (batches, *, schema=None))]
-    pub fn from_batches(
+    fn from_batches(
         _cls: &Bound<PyType>,
         batches: Vec<PyRecordBatch>,
         schema: Option<PySchema>,
@@ -156,7 +163,7 @@ impl PyTable {
             let schema = schema.ok_or(PyValueError::new_err(
                 "schema must be passed for an empty list of batches",
             ))?;
-            return Ok(Self::new(vec![], schema.into_inner()));
+            return Ok(Self::try_new(vec![], schema.into_inner())?);
         }
 
         let batches = batches
@@ -166,12 +173,12 @@ impl PyTable {
         let schema = schema
             .map(|s| s.into_inner())
             .unwrap_or(batches.first().unwrap().schema());
-        Ok(Self::new(batches, schema))
+        Ok(Self::try_new(batches, schema)?)
     }
 
     #[classmethod]
     #[pyo3(signature = (mapping, *, schema=None, metadata=None))]
-    pub fn from_pydict(
+    fn from_pydict(
         cls: &Bound<PyType>,
         mapping: IndexMap<String, AnyArray>,
         schema: Option<PySchema>,
@@ -183,7 +190,7 @@ impl PyTable {
 
     #[classmethod]
     #[pyo3(signature = (arrays, *, names=None, schema=None, metadata=None))]
-    pub fn from_arrays(
+    fn from_arrays(
         _cls: &Bound<PyType>,
         arrays: Vec<AnyArray>,
         names: Option<Vec<String>>,
@@ -214,7 +221,7 @@ impl PyTable {
         };
 
         if columns.is_empty() {
-            return Ok(Self::new(vec![], schema));
+            return Ok(Self::try_new(vec![], schema)?);
         }
 
         let column_chunk_lengths = columns
@@ -247,10 +254,10 @@ impl PyTable {
             batches.push(batch);
         }
 
-        Ok(Self::new(batches, schema))
+        Ok(Self::try_new(batches, schema)?)
     }
 
-    pub fn add_column(
+    fn add_column(
         &self,
         py: Python,
         i: usize,
@@ -289,10 +296,10 @@ impl PyTable {
             })
             .collect::<Result<Vec<_>, PyArrowError>>()?;
 
-        Ok(PyTable::new(new_batches, new_schema).to_arro3(py)?)
+        Ok(PyTable::try_new(new_batches, new_schema)?.to_arro3(py)?)
     }
 
-    pub fn append_column(
+    fn append_column(
         &self,
         py: Python,
         field: NameOrField,
@@ -330,15 +337,15 @@ impl PyTable {
             })
             .collect::<Result<Vec<_>, PyArrowError>>()?;
 
-        Ok(PyTable::new(new_batches, new_schema).to_arro3(py)?)
+        Ok(PyTable::try_new(new_batches, new_schema)?.to_arro3(py)?)
     }
 
     #[getter]
-    pub fn chunk_lengths(&self) -> Vec<usize> {
+    fn chunk_lengths(&self) -> Vec<usize> {
         self.batches.iter().map(|batch| batch.num_rows()).collect()
     }
 
-    pub fn column(&self, py: Python, i: FieldIndexInput) -> PyArrowResult<PyObject> {
+    fn column(&self, py: Python, i: FieldIndexInput) -> PyArrowResult<PyObject> {
         let column_index = i.into_position(&self.schema)?;
         let field = self.schema.field(column_index).clone();
         let chunks = self
@@ -346,11 +353,11 @@ impl PyTable {
             .iter()
             .map(|batch| batch.column(column_index).clone())
             .collect();
-        Ok(PyChunkedArray::new(chunks, field.into()).to_arro3(py)?)
+        Ok(PyChunkedArray::try_new(chunks, field.into())?.to_arro3(py)?)
     }
 
     #[getter]
-    pub fn column_names(&self) -> Vec<String> {
+    fn column_names(&self) -> Vec<String> {
         self.schema
             .fields()
             .iter()
@@ -359,18 +366,18 @@ impl PyTable {
     }
 
     #[getter]
-    pub fn columns(&self, py: Python) -> PyArrowResult<Vec<PyObject>> {
+    fn columns(&self, py: Python) -> PyArrowResult<Vec<PyObject>> {
         (0..self.num_columns())
             .map(|i| self.column(py, FieldIndexInput::Position(i)))
             .collect()
     }
 
-    pub fn combine_chunks(&self, py: Python) -> PyArrowResult<PyObject> {
+    fn combine_chunks(&self, py: Python) -> PyArrowResult<PyObject> {
         let batch = concat_batches(&self.schema, &self.batches)?;
-        Ok(PyTable::new(vec![batch], self.schema.clone()).to_arro3(py)?)
+        Ok(PyTable::try_new(vec![batch], self.schema.clone())?.to_arro3(py)?)
     }
 
-    pub fn field(&self, py: Python, i: FieldIndexInput) -> PyArrowResult<PyObject> {
+    fn field(&self, py: Python, i: FieldIndexInput) -> PyArrowResult<PyObject> {
         let field = self.schema.field(i.into_position(&self.schema)?);
         Ok(PyField::new(field.clone().into()).to_arro3(py)?)
     }
@@ -383,20 +390,20 @@ impl PyTable {
     }
 
     #[getter]
-    pub fn num_columns(&self) -> usize {
+    fn num_columns(&self) -> usize {
         self.schema.fields().len()
     }
 
     #[getter]
-    pub fn num_rows(&self) -> usize {
+    fn num_rows(&self) -> usize {
         self.batches()
             .iter()
             .fold(0, |acc, batch| acc + batch.num_rows())
     }
 
-    // pub fn rechunk(&self, py: Python, max_chunksize: usize) {}
+    //  fn rechunk(&self, py: Python, max_chunksize: usize) {}
 
-    pub fn remove_column(&self, py: Python, i: usize) -> PyArrowResult<PyObject> {
+    fn remove_column(&self, py: Python, i: usize) -> PyArrowResult<PyObject> {
         let mut fields = self.schema.fields().to_vec();
         fields.remove(i);
         let new_schema = Arc::new(Schema::new_with_metadata(
@@ -414,10 +421,10 @@ impl PyTable {
             })
             .collect::<Result<Vec<_>, PyArrowError>>()?;
 
-        Ok(PyTable::new(new_batches, new_schema).to_arro3(py)?)
+        Ok(PyTable::try_new(new_batches, new_schema)?.to_arro3(py)?)
     }
 
-    pub fn rename_columns(&self, py: Python, names: Vec<String>) -> PyArrowResult<PyObject> {
+    fn rename_columns(&self, py: Python, names: Vec<String>) -> PyArrowResult<PyObject> {
         if names.len() != self.num_columns() {
             return Err(PyValueError::new_err("When names is a list[str], must pass the same number of names as there are columns.").into());
         }
@@ -433,15 +440,15 @@ impl PyTable {
             new_fields,
             self.schema.metadata().clone(),
         ));
-        Ok(PyTable::new(self.batches.clone(), new_schema).to_arro3(py)?)
+        Ok(PyTable::try_new(self.batches.clone(), new_schema)?.to_arro3(py)?)
     }
 
     #[getter]
-    pub fn schema(&self, py: Python) -> PyResult<PyObject> {
+    fn schema(&self, py: Python) -> PyResult<PyObject> {
         PySchema::new(self.schema.clone()).to_arro3(py)
     }
 
-    pub fn select(&self, py: Python, columns: SelectIndices) -> PyArrowResult<PyObject> {
+    fn select(&self, py: Python, columns: SelectIndices) -> PyArrowResult<PyObject> {
         let positions = columns.into_positions(self.schema.fields())?;
 
         let new_schema = Arc::new(self.schema.project(&positions)?);
@@ -450,10 +457,10 @@ impl PyTable {
             .iter()
             .map(|batch| batch.project(&positions))
             .collect::<Result<Vec<_>, ArrowError>>()?;
-        Ok(PyTable::new(new_batches, new_schema).to_arro3(py)?)
+        Ok(PyTable::try_new(new_batches, new_schema)?.to_arro3(py)?)
     }
 
-    pub fn set_column(
+    fn set_column(
         &self,
         py: Python,
         i: usize,
@@ -492,22 +499,22 @@ impl PyTable {
             })
             .collect::<Result<Vec<_>, PyArrowError>>()?;
 
-        Ok(PyTable::new(new_batches, new_schema).to_arro3(py)?)
+        Ok(PyTable::try_new(new_batches, new_schema)?.to_arro3(py)?)
     }
 
     #[getter]
-    pub fn shape(&self) -> (usize, usize) {
+    fn shape(&self) -> (usize, usize) {
         (self.num_rows(), self.num_columns())
     }
 
-    pub fn to_batches(&self, py: Python) -> PyResult<Vec<PyObject>> {
+    fn to_batches(&self, py: Python) -> PyResult<Vec<PyObject>> {
         self.batches
             .iter()
             .map(|batch| PyRecordBatch::new(batch.clone()).to_arro3(py))
             .collect()
     }
 
-    pub fn to_reader(&self, py: Python) -> PyResult<PyObject> {
+    fn to_reader(&self, py: Python) -> PyResult<PyObject> {
         let reader = Box::new(RecordBatchIterator::new(
             self.batches.clone().into_iter().map(Ok),
             self.schema.clone(),
@@ -515,7 +522,7 @@ impl PyTable {
         PyRecordBatchReader::new(reader).to_arro3(py)
     }
 
-    pub fn to_struct_array(&self, py: Python) -> PyArrowResult<PyObject> {
+    fn to_struct_array(&self, py: Python) -> PyArrowResult<PyObject> {
         let chunks = self
             .batches
             .iter()
@@ -526,16 +533,16 @@ impl PyTable {
             .collect::<Vec<_>>();
         let field = Field::new_struct("", self.schema.fields().clone(), false)
             .with_metadata(self.schema.metadata.clone());
-        Ok(PyChunkedArray::new(chunks, field.into()).to_arro3(py)?)
+        Ok(PyChunkedArray::try_new(chunks, field.into())?.to_arro3(py)?)
     }
 
-    pub fn with_schema(&self, py: Python, schema: PySchema) -> PyArrowResult<PyObject> {
+    fn with_schema(&self, py: Python, schema: PySchema) -> PyArrowResult<PyObject> {
         let new_schema = schema.into_inner();
         let new_batches = self
             .batches
             .iter()
             .map(|batch| RecordBatch::try_new(new_schema.clone(), batch.columns().to_vec()))
             .collect::<Result<Vec<_>, ArrowError>>()?;
-        Ok(PyTable::new(new_batches, new_schema).to_arro3(py)?)
+        Ok(PyTable::try_new(new_batches, new_schema)?.to_arro3(py)?)
     }
 }


### PR DESCRIPTION
### Change list

- Convert nearly all methods exported to Python via arro3-core to non-public Rust visibility
- Add `#![deny(missing_docs)]` and add Rust docstrings
- Add `allow_inspection: false` to the `mkdocs.yml` config so that the Rust docstrings aren't used for Python docs.