### PR TITLE
Casting fallback in PyCapsule export

### DIFF
--- a/pyo3-arrow/src/ffi/to_python/utils.rs
+++ b/pyo3-arrow/src/ffi/to_python/utils.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 use std::sync::Arc;
 
+use arrow::compute::can_cast_types;
 use arrow::compute::kernels::cast;
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_array::Array;
@@ -40,11 +41,17 @@ pub fn to_array_pycapsules<'py>(
         // Note: we don't import a Field directly because the name might not be set.
         // https://github.com/apache/arrow-rs/issues/6251
         let data_type = DataType::try_from(schema_ptr)?;
-        let field =
-            Arc::new(Field::new("", data_type, true).with_metadata(field.metadata().clone()));
 
-        let casted_array = cast(array, field.data_type())?;
-        (casted_array.to_data(), field)
+        // Only cast the array if we can cast the types.
+        if can_cast_types(field.data_type(), &data_type) {
+            let field =
+                Arc::new(Field::new("", data_type, true).with_metadata(field.metadata().clone()));
+
+            let casted_array = cast(array, field.data_type())?;
+            (casted_array.to_data(), field)
+        } else {
+            (array.to_data(), field)
+        }
     } else {
         (array.to_data(), field)
     };
@@ -78,16 +85,20 @@ pub fn to_stream_pycapsule<'py>(
         // Note: we don't import a Field directly because the name might not be set.
         // https://github.com/apache/arrow-rs/issues/6251
         let data_type = DataType::try_from(schema_ptr)?;
-        let field = Arc::new(
-            Field::new("", data_type, true).with_metadata(existing_field.metadata().clone()),
-        );
 
-        let output_field = field.clone();
-        let array_iter = array_reader.map(move |array| {
-            let out = cast(array?.as_ref(), field.data_type())?;
-            Ok(out)
-        });
-        array_reader = Box::new(ArrayIterator::new(array_iter, output_field));
+        // Only cast the reader if we can cast the types.
+        if can_cast_types(existing_field.data_type(), &data_type) {
+            let field = Arc::new(
+                Field::new("", data_type, true).with_metadata(existing_field.metadata().clone()),
+            );
+
+            let output_field = field.clone();
+            let array_iter = array_reader.map(move |array| {
+                let out = cast(array?.as_ref(), field.data_type())?;
+                Ok(out)
+            });
+            array_reader = Box::new(ArrayIterator::new(array_iter, output_field));
+        }
     }
 
     let ffi_stream = new_stream(array_reader);


### PR DESCRIPTION
> The callee should attempt to provide the data in the requested schema. However, if the callee cannot provide the data in the requested schema, they may return with the same schema as if `None` were passed to `requested_schema`.

This updates the data export to check if we can cast the data via `can_cast_types`. If we can't cast the types, we do nothing.