### PR TITLE
Set strip=true for maturin builds

### DIFF
--- a/arro3-compute/pyproject.toml
+++ b/arro3-compute/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 features = ["pyo3/extension-module"]
 module-name = "arro3.compute._compute"
 python-source = "python"
+strip = true
 
 [tool.poetry]
 name = "arro3-compute"

--- a/arro3-core/pyproject.toml
+++ b/arro3-core/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 features = ["pyo3/extension-module"]
 module-name = "arro3.core._core"
 python-source = "python"
+strip = true
 
 [tool.poetry]
 name = "arro3-core"

--- a/arro3-io/pyproject.toml
+++ b/arro3-io/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 features = ["pyo3/extension-module"]
 module-name = "arro3.io._io"
 python-source = "python"
+strip = true
 
 [tool.poetry]
 name = "arro3-io"


### PR DESCRIPTION
Minimizes built file size. 

Reduces the wheel size of arro3-io from 4611601 bytes to 4066830, a 12% reduction in size.

