### PR TITLE
Fix arg name in from_arrays

### DIFF
--- a/arro3-core/python/arro3/core/_core.pyi
+++ b/arro3-core/python/arro3/core/_core.pyi
@@ -175,7 +175,7 @@ class ArrayReader:
         """Construct this object from a bare Arrow PyCapsule"""
     @classmethod
     def from_arrays(
-        cls, schema: ArrowSchemaExportable, arrays: Sequence[ArrowArrayExportable]
+        cls, field: ArrowSchemaExportable, arrays: Sequence[ArrowArrayExportable]
     ) -> ArrayReader: ...
     @classmethod
     def from_stream(cls, data: ArrowStreamExportable) -> ArrayReader:


### PR DESCRIPTION
This matches the rust definition: 
https://github.com/kylebarron/arro3/blob/f8bb60f4907d904990187c4dd8b1720ec2446f5e/pyo3-arrow/src/array_reader.rs#L160