### PR TITLE
Avoid runtime dependency on numpy when importing arro3.core.types

### DIFF
--- a/arro3-core/python/arro3/core/types.py
+++ b/arro3-core/python/arro3/core/types.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol, Tuple, Union
+from typing import TYPE_CHECKING, Protocol, Tuple, Union
 
-import numpy as np
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class ArrowSchemaExportable(Protocol):
@@ -78,7 +79,7 @@ class BufferProtocolExportable(Protocol):
 
 
 # Numpy arrays don't yet declare `__buffer__` (or maybe just on a very recent version)
-ArrayInput = Union[ArrowArrayExportable, BufferProtocolExportable, np.ndarray]
+ArrayInput = Union[ArrowArrayExportable, BufferProtocolExportable, "np.ndarray"]
 """Accepted input as an Arrow array.
 
 Buffer protocol input (such as numpy arrays) will be interpreted zero-copy except in the


### PR DESCRIPTION
By building from source or installing the most recent pre-release on an empty virtual environment.
```python
from arro3.core.types import ArrowSchemaExportable
# ModuleNotFoundError: No module named 'numpy'
```
Actually importing `numpy` may not be needed and we can get by with just a `if TYPE_CHECKING` condition and a forward reference.