### PR TITLE
Fix NameError when importing arro3.core.types

### DIFF
--- a/arro3-core/python/arro3/core/types.py
+++ b/arro3-core/python/arro3/core/types.py
@@ -79,7 +79,7 @@ class BufferProtocolExportable(Protocol):
 
 
 # Numpy arrays don't yet declare `__buffer__` (or maybe just on a very recent version)
-ArrayInput = Union[ArrowArrayExportable, BufferProtocolExportable, np.ndarray]
+ArrayInput = Union[ArrowArrayExportable, BufferProtocolExportable, "np.ndarray"]
 """Accepted input as an Arrow array.
 
 Buffer protocol input (such as numpy arrays) will be interpreted zero-copy except in the


### PR DESCRIPTION
A follow-up to my previous pull request (#210)
I made a comment about the the need for a string forward-reference (https://github.com/kylebarron/arro3/pull/210#discussion_r1785286666) but noticed shortly afterwards that the pull request has already been merged. 😅 