### PR TITLE
Migrate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
   python: python3
 
 # Optionally both commit and push
-default_stages: [commit]
+default_stages: [pre-commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
While working on #236 I have noticed that the `pre-commit` configuration was not up to date (probably following the release of `pre-commit==4.0.0` few days ago?) with the following [warning](https://github.com/kylebarron/arro3/actions/runs/11333231739/job/31516956348?pr=236#step:5:44)
```console
[WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```
