### PR TITLE
Remove 32-bit windows wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -99,8 +99,6 @@ jobs:
       matrix:
         platform:
           - runner: windows-latest
-            target: x64
-          - runner: windows-latest
             target: x86
         module:
           - arro3-core


### PR DESCRIPTION
Closes #235 

numpy 0.22 dropped support for 32-bit windows: https://github.com/PyO3/rust-numpy/pull/442#issuecomment-2386945975