### PR TITLE
WIP: async stream of Arrow record batches from Parquet file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,10 +112,11 @@ dependencies = [
  "parquet",
  "pyo3",
  "pyo3-arrow",
- "pyo3-async-runtimes",
+ "pyo3-async-runtimes 0.21.0",
  "pyo3-file",
  "pyo3-object_store",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1561,6 +1562,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-async-runtimes"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2529f0be73ffd2be0cc43c013a640796558aa12d7ca0aab5cc14f375b4733031"
+dependencies = [
+ "futures",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
 name = "pyo3-build-config"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,14 +1630,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.1.0"
-source = "git+https://github.com/developmentseed/object-store-rs?rev=922b58ff784271345ce80342cf4cd6cddce61adf#922b58ff784271345ce80342cf4cd6cddce61adf"
+version = "0.1.0-beta.1"
+source = "git+https://github.com/developmentseed/obstore?rev=f0dad90f1e5e157760335d1ccb4045e1f3b4f194#f0dad90f1e5e157760335d1ccb4045e1f3b4f194"
 dependencies = [
  "futures",
  "object_store",
  "pyo3",
- "pyo3-async-runtimes",
+ "pyo3-async-runtimes 0.22.0",
  "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -2181,9 +2196,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",

--- a/arro3-io/Cargo.toml
+++ b/arro3-io/Cargo.toml
@@ -45,5 +45,6 @@ pyo3-async-runtimes = { workspace = true, features = [
     "tokio-runtime",
 ], optional = true }
 pyo3-file = { workspace = true }
-pyo3-object_store = { git = "https://github.com/developmentseed/object-store-rs", rev = "922b58ff784271345ce80342cf4cd6cddce61adf", optional = true }
+pyo3-object_store = { git = "https://github.com/developmentseed/obstore", rev = "f0dad90f1e5e157760335d1ccb4045e1f3b4f194", optional = true }
 thiserror = { workspace = true }
+tokio = "1.41.1"

--- a/arro3-io/python/arro3/io/_io.pyi
+++ b/arro3-io/python/arro3/io/_io.pyi
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import IO, Literal, Sequence
+from typing import IO, Literal, Self, Sequence
 
 # Note: importing with
 # `from arro3.core import Array`
@@ -267,6 +267,24 @@ ParquetEncoding = Literal[
 ]
 """Allowed Parquet encodings."""
 
+class ParquetRecordBatchStream:
+    """
+    A stream of [RecordBatch][core.RecordBatch] that can be polled in a sync or
+    async fashion.
+    """
+
+    def __aiter__(self) -> Self:
+        """Return `Self` as an async iterator."""
+
+    def __iter__(self) -> Self:
+        """Return `Self` as an async iterator."""
+
+    async def collect_async(self) -> core.Table:
+        """Collect all remaining batches in the stream into a table."""
+
+    async def __anext__(self) -> core.RecordBatch:
+        """Return the next record batch in the stream."""
+
 def read_parquet(file: IO[bytes] | Path | str) -> core.RecordBatchReader:
     """Read a Parquet file to an Arrow RecordBatchReader
 
@@ -277,8 +295,10 @@ def read_parquet(file: IO[bytes] | Path | str) -> core.RecordBatchReader:
         The loaded Arrow data.
     """
 
-async def read_parquet_async(path: str, *, store: ObjectStore) -> core.Table:
-    """Read a Parquet file to an Arrow Table in an async fashion
+async def read_parquet_async(
+    path: str, *, store: ObjectStore
+) -> ParquetRecordBatchStream:
+    """Create an async stream of Arrow record batches from a Parquet file.
 
     Args:
         file: The path to the Parquet file in the given store

--- a/arro3-io/src/lib.rs
+++ b/arro3-io/src/lib.rs
@@ -40,6 +40,7 @@ fn _io(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(___version))?;
 
     pyo3_object_store::register_store_module(py, m, "arro3.io")?;
+    pyo3_object_store::register_exceptions_module(py, m, "arro3.io")?;
 
     m.add_wrapped(wrap_pyfunction!(csv::infer_csv_schema))?;
     m.add_wrapped(wrap_pyfunction!(csv::read_csv))?;

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -52,10 +52,12 @@ async def test_stream_parquet():
     url = "https://overturemaps-us-west-2.s3.amazonaws.com/release/2024-03-12-alpha.0/theme=buildings/type=building/part-00217-4dfc75cd-2680-4d52-b5e0-f4cc9f36b267-c000.zstd.parquet"
     store = HTTPStore.from_url(url)
     stream = await read_parquet_async("", store=store)
-    first = await stream.__anext__()
     t1 = time()
+    first = await stream.__anext__()
+    t2 = time()
 
     print(t1 - t0)
+    print(t2 - t1)
 
     test = await stream.collect_async()
     len(test)


### PR DESCRIPTION
This takes just 1.1s for the stream to start and then 1.0s more for the first record batch to be fetched. While it's >60s for the full file to download on my internet.

```py
from time import time

t0 = time()
url = "https://overturemaps-us-west-2.s3.amazonaws.com/release/2024-03-12-alpha.0/theme=buildings/type=building/part-00217-4dfc75cd-2680-4d52-b5e0-f4cc9f36b267-c000.zstd.parquet"
store = HTTPStore.from_url(url)
stream = await read_parquet_async("", store=store)
t1 = time()
first = await stream.__anext__()
t2 = time()

print(t1 - t0) # 1.1302871704101562
print(t2 - t1) # 1.0420188903808594
```
