### PR TITLE
Don't build 3.13 wheels on windows

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -132,7 +132,9 @@ jobs:
           version: "0.4.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+        # Note: we exclude 3.13 from Windows, because it failed with a link error
+        # https://github.com/kylebarron/arro3/actions/runs/11957080778/job/33333367496
+        run: uv python install 3.9 3.10 3.11 3.12 pypy3.10
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
Hitting a linking error

```
error: linking with `link.exe` failed: exit code: 1181
  |
  = note: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\bin\\HostX64\\x64\\link.exe" "/DEF:C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcNQis9O\\lib.def" "/NOLOGO" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcNQis9O\\symbols.o" "D:\\a\\arro3\\arro3\\target\\x86_64-pc-windows-msvc\\release\\deps\\_core._core.586b6f7ebc2fe781-cgu.0.rcgu.o" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcNQis9O\\libstd-2df1f22abef96888.rlib" "C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libcompiler_builtins-e3a3e7896142045d.rlib" "bcrypt.lib" "advapi32.lib" "python313.lib" "legacy_stdio_definitions.lib" "windows.0.52.0.lib" "kernel32.lib" "kernel32.lib" "advapi32.lib" "ntdll.lib" "userenv.lib" "ws2_32.lib" "dbghelp.lib" "/defaultlib:msvcrt" "/NXCOMPAT" "/LIBPATH:C:\\Users\\runneradmin\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\windows_x86_64_msvc-0.52.6\\lib" "/OUT:D:\\a\\arro3\\arro3\\target\\x86_64-pc-windows-msvc\\release\\deps\\_core.dll" "/OPT:REF,ICF" "/DLL" "/IMPLIB:D:\\a\\arro3\\arro3\\target\\x86_64-pc-windows-msvc\\release\\deps\\_core.dll.lib" "/DEBUG" "/PDBALTPATH:%_PDB%" "/NATVIS:C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\intrinsic.natvis" "/NATVIS:C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\liballoc.natvis" "/NATVIS:C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libcore.natvis" "/NATVIS:C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libstd.natvis"
  = note: LINK : fatal error LNK1181: cannot open input file 'python313.lib'␍
```