### PR TITLE
Avoid returning `PyObject` and add wrapper types for arro3 export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,8 +1620,6 @@ dependencies = [
 [[package]]
 name = "pyo3-arrow"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d66e6404efa94448d1648868170d9e50a9e6b4e9c3ec336605587af70ad28c"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ numpy = "0.23"
 object_store = "0.11"
 parquet = "53"
 pyo3 = { version = "0.23", features = ["macros", "indexmap"] }
-pyo3-arrow = "0.6"
-# pyo3-arrow = { path = "./pyo3-arrow" }
+# pyo3-arrow = "0.6"
+pyo3-arrow = { path = "./pyo3-arrow" }
 pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
 pyo3-file = "0.10"
 pyo3-object_store = { git = "https://github.com/developmentseed/object-store-rs", rev = "bad34862a92849dd7b69c28cd4c225446d3d15ab" }

--- a/arro3-compute/src/aggregate.rs
+++ b/arro3-compute/src/aggregate.rs
@@ -13,16 +13,17 @@ use arrow_schema::{ArrowError, DataType};
 use arrow_select::concat;
 use pyo3::prelude::*;
 use pyo3_arrow::error::PyArrowResult;
+use pyo3_arrow::export::Arro3Scalar;
 use pyo3_arrow::input::AnyArray;
 use pyo3_arrow::PyScalar;
 
 #[pyfunction]
-pub fn max(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
+pub fn max(input: AnyArray) -> PyArrowResult<Arro3Scalar> {
     match input {
         AnyArray::Array(array) => {
             let (array, field) = array.into_inner();
             let result = max_array(array)?;
-            Ok(PyScalar::try_new(result, field)?.to_arro3(py)?)
+            Ok(PyScalar::try_new(result, field)?.into())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -43,7 +44,7 @@ pub fn max(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
 
             // Call max_array on intermediate outputs
             let result = max_array(concatted)?;
-            Ok(PyScalar::try_new(result, field)?.to_arro3(py)?)
+            Ok(PyScalar::try_new(result, field)?.into())
         }
     }
 }
@@ -112,12 +113,12 @@ fn max_boolean(array: &BooleanArray) -> ArrayRef {
 }
 
 #[pyfunction]
-pub fn min(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
+pub fn min(input: AnyArray) -> PyArrowResult<Arro3Scalar> {
     match input {
         AnyArray::Array(array) => {
             let (array, field) = array.into_inner();
             let result = min_array(array)?;
-            Ok(PyScalar::try_new(result, field)?.to_arro3(py)?)
+            Ok(PyScalar::try_new(result, field)?.into())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -138,7 +139,7 @@ pub fn min(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
 
             // Call min_array on intermediate outputs
             let result = min_array(concatted)?;
-            Ok(PyScalar::try_new(result, field)?.to_arro3(py)?)
+            Ok(PyScalar::try_new(result, field)?.into())
         }
     }
 }
@@ -207,12 +208,12 @@ fn min_boolean(array: &BooleanArray) -> ArrayRef {
 }
 
 #[pyfunction]
-pub fn sum(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
+pub fn sum(input: AnyArray) -> PyArrowResult<Arro3Scalar> {
     match input {
         AnyArray::Array(array) => {
             let (array, field) = array.into_inner();
             let result = sum_array(array)?;
-            Ok(PyScalar::try_new(result, field)?.to_arro3(py)?)
+            Ok(PyScalar::try_new(result, field)?.into())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -233,7 +234,7 @@ pub fn sum(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
 
             // Call sum_array on intermediate outputs
             let result = sum_array(concatted)?;
-            Ok(PyScalar::try_new(result, field)?.to_arro3(py)?)
+            Ok(PyScalar::try_new(result, field)?.into())
         }
     }
 }

--- a/arro3-compute/src/arith.rs
+++ b/arro3-compute/src/arith.rs
@@ -6,50 +6,72 @@ use pyo3_arrow::PyArray;
 
 #[pyfunction]
 pub fn add(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::add(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::add(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn add_wrapping(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::add_wrapping(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::add_wrapping(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn div(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::div(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::div(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn mul(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::mul(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::mul(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn mul_wrapping(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::mul_wrapping(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::mul_wrapping(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn neg(py: Python, array: PyArray) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::neg(array.as_ref())?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::neg(array.as_ref())?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn neg_wrapping(py: Python, array: PyArray) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::neg_wrapping(array.as_ref())?).to_arro3(py)?)
+    Ok(
+        PyArray::from_array_ref(numeric::neg_wrapping(array.as_ref())?)
+            .to_arro3(py)?
+            .unbind(),
+    )
 }
 
 #[pyfunction]
 pub fn rem(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::rem(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::rem(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn sub(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::sub(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::sub(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }
 
 #[pyfunction]
 pub fn sub_wrapping(py: Python, lhs: AnyDatum, rhs: AnyDatum) -> PyArrowResult<PyObject> {
-    Ok(PyArray::from_array_ref(numeric::sub_wrapping(&lhs, &rhs)?).to_arro3(py)?)
+    Ok(PyArray::from_array_ref(numeric::sub_wrapping(&lhs, &rhs)?)
+        .to_arro3(py)?
+        .unbind())
 }

--- a/arro3-compute/src/boolean.rs
+++ b/arro3-compute/src/boolean.rs
@@ -13,7 +13,9 @@ pub fn is_null(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
     match input {
         AnyArray::Array(input) => {
             let out = arrow::compute::is_null(input.as_ref())?;
-            Ok(PyArray::from_array_ref(Arc::new(out)).to_arro3(py)?)
+            Ok(PyArray::from_array_ref(Arc::new(out))
+                .to_arro3(py)?
+                .unbind())
         }
         AnyArray::Stream(input) => {
             let input = input.into_reader()?;
@@ -25,7 +27,8 @@ pub fn is_null(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
             });
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, out_field.into())))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }
@@ -36,7 +39,9 @@ pub fn is_not_null(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
     match input {
         AnyArray::Array(input) => {
             let out = arrow::compute::is_not_null(input.as_ref())?;
-            Ok(PyArray::from_array_ref(Arc::new(out)).to_arro3(py)?)
+            Ok(PyArray::from_array_ref(Arc::new(out))
+                .to_arro3(py)?
+                .unbind())
         }
         AnyArray::Stream(input) => {
             let input = input.into_reader()?;
@@ -48,7 +53,8 @@ pub fn is_not_null(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
             });
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, out_field.into())))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }

--- a/arro3-compute/src/cast.rs
+++ b/arro3-compute/src/cast.rs
@@ -17,7 +17,7 @@ pub fn cast(py: Python, input: AnyArray, to_type: PyField) -> PyArrowResult<PyOb
         AnyArray::Array(arr) => {
             let new_field = to_type.into_inner();
             let out = arrow_cast::cast(arr.as_ref(), new_field.data_type())?;
-            Ok(PyArray::new(out, new_field).to_arro3(py)?)
+            Ok(PyArray::new(out, new_field).to_arro3(py)?.unbind())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -36,7 +36,11 @@ pub fn cast(py: Python, input: AnyArray, to_type: PyField) -> PyArrowResult<PyOb
             let iter = reader
                 .into_iter()
                 .map(move |array| arrow_cast::cast(&array?, &to_type));
-            Ok(PyArrayReader::new(Box::new(ArrayIterator::new(iter, new_field))).to_arro3(py)?)
+            Ok(
+                PyArrayReader::new(Box::new(ArrayIterator::new(iter, new_field)))
+                    .to_arro3(py)?
+                    .unbind(),
+            )
         }
     }
 }

--- a/arro3-compute/src/concat.rs
+++ b/arro3-compute/src/concat.rs
@@ -7,5 +7,5 @@ pub fn concat(py: Python, input: PyChunkedArray) -> PyArrowResult<PyObject> {
     let (chunks, field) = input.into_inner();
     let array_refs = chunks.iter().map(|arr| arr.as_ref()).collect::<Vec<_>>();
     let concatted = arrow_select::concat::concat(array_refs.as_slice())?;
-    Ok(PyArray::new(concatted, field).to_arro3(py)?)
+    Ok(PyArray::new(concatted, field).to_arro3(py)?.unbind())
 }

--- a/arro3-compute/src/dictionary.rs
+++ b/arro3-compute/src/dictionary.rs
@@ -20,7 +20,7 @@ pub(crate) fn dictionary_encode(py: Python, array: AnyArray) -> PyArrowResult<Py
         AnyArray::Array(array) => {
             let (array, _field) = array.into_inner();
             let output_array = dictionary_encode_array(array)?;
-            Ok(PyArray::from_array_ref(output_array).to_arro3(py)?)
+            Ok(PyArray::from_array_ref(output_array).to_arro3(py)?.unbind())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -37,7 +37,8 @@ pub(crate) fn dictionary_encode(py: Python, array: AnyArray) -> PyArrowResult<Py
                 .map(move |array| dictionary_encode_array(array?));
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, output_field.into())))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }

--- a/arro3-compute/src/filter.rs
+++ b/arro3-compute/src/filter.rs
@@ -20,7 +20,7 @@ pub fn filter(py: Python, values: AnyArray, predicate: AnyArray) -> PyArrowResul
                 ))?;
 
             let filtered = arrow::compute::filter(values.as_ref(), predicate)?;
-            Ok(PyArray::new(filtered, values_field).to_arro3(py)?)
+            Ok(PyArray::new(filtered, values_field).to_arro3(py)?.unbind())
         }
         (AnyArray::Stream(values), AnyArray::Stream(predicate)) => {
             let values = values.into_reader()?;
@@ -47,7 +47,8 @@ pub fn filter(py: Python, values: AnyArray, predicate: AnyArray) -> PyArrowResul
                 });
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, values_field)))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
         _ => Err(PyValueError::new_err("Unsupported combination of array and stream").into()),

--- a/arro3-compute/src/take.rs
+++ b/arro3-compute/src/take.rs
@@ -8,5 +8,7 @@ use pyo3_arrow::PyArray;
 pub fn take(py: Python, values: PyArray, indices: PyArray) -> PyArrowResult<PyObject> {
     let output_array =
         py.allow_threads(|| arrow_select::take::take(values.as_ref(), indices.as_ref(), None))?;
-    Ok(PyArray::new(output_array, values.field().clone()).to_arro3(py)?)
+    Ok(PyArray::new(output_array, values.field().clone())
+        .to_arro3(py)?
+        .unbind())
 }

--- a/arro3-compute/src/temporal.rs
+++ b/arro3-compute/src/temporal.rs
@@ -86,7 +86,7 @@ pub fn date_part(py: Python, input: AnyArray, part: DatePart) -> PyArrowResult<P
     match input {
         AnyArray::Array(input) => {
             let out = arrow::compute::date_part(input.as_ref(), part.into())?;
-            Ok(PyArray::from_array_ref(out).to_arro3(py)?)
+            Ok(PyArray::from_array_ref(out).to_arro3(py)?.unbind())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -98,7 +98,8 @@ pub fn date_part(py: Python, input: AnyArray, part: DatePart) -> PyArrowResult<P
                 .map(move |array| arrow::compute::date_part(array?.as_ref(), part));
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, output_field.into())))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }

--- a/arro3-core/src/accessors/dictionary.rs
+++ b/arro3-core/src/accessors/dictionary.rs
@@ -13,7 +13,7 @@ pub(crate) fn dictionary_indices(py: Python, array: AnyArray) -> PyArrowResult<P
         AnyArray::Array(array) => {
             let (array, _field) = array.into_inner();
             let output_array = _dictionary_indices(array)?;
-            Ok(PyArray::from_array_ref(output_array).to_arro3(py)?)
+            Ok(PyArray::from_array_ref(output_array).to_arro3(py)?.unbind())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -34,7 +34,8 @@ pub(crate) fn dictionary_indices(py: Python, array: AnyArray) -> PyArrowResult<P
                 .map(move |array| _dictionary_indices(array?));
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, out_field.into())))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }
@@ -49,7 +50,7 @@ pub(crate) fn dictionary_dictionary(py: Python, array: AnyArray) -> PyArrowResul
         AnyArray::Array(array) => {
             let (array, _field) = array.into_inner();
             let output_array = _dictionary_dictionary(array)?;
-            Ok(PyArray::from_array_ref(output_array).to_arro3(py)?)
+            Ok(PyArray::from_array_ref(output_array).to_arro3(py)?.unbind())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -70,7 +71,8 @@ pub(crate) fn dictionary_dictionary(py: Python, array: AnyArray) -> PyArrowResul
                 .map(move |array| _dictionary_dictionary(array?));
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, out_field.into())))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }

--- a/arro3-core/src/accessors/list_flatten.rs
+++ b/arro3-core/src/accessors/list_flatten.rs
@@ -14,7 +14,7 @@ pub fn list_flatten(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
             let (array, field) = array.into_inner();
             let flat_array = flatten_array(array)?;
             let flat_field = flatten_field(field)?;
-            Ok(PyArray::new(flat_array, flat_field).to_arro3(py)?)
+            Ok(PyArray::new(flat_array, flat_field).to_arro3(py)?.unbind())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -26,7 +26,8 @@ pub fn list_flatten(py: Python, input: AnyArray) -> PyArrowResult<PyObject> {
             });
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, flatten_field)))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }

--- a/arro3-core/src/accessors/list_offsets.rs
+++ b/arro3-core/src/accessors/list_offsets.rs
@@ -17,7 +17,7 @@ pub fn list_offsets(py: Python, input: AnyArray, logical: bool) -> PyArrowResult
         AnyArray::Array(array) => {
             let (array, _field) = array.into_inner();
             let offsets = _list_offsets(array, logical)?;
-            Ok(PyArray::from_array_ref(offsets).to_arro3(py)?)
+            Ok(PyArray::from_array_ref(offsets).to_arro3(py)?.unbind())
         }
         AnyArray::Stream(stream) => {
             let reader = stream.into_reader()?;
@@ -36,7 +36,8 @@ pub fn list_offsets(py: Python, input: AnyArray, logical: bool) -> PyArrowResult
                 .map(move |array| _list_offsets(array?, logical));
             Ok(
                 PyArrayReader::new(Box::new(ArrayIterator::new(iter, out_field.into())))
-                    .to_arro3(py)?,
+                    .to_arro3(py)?
+                    .unbind(),
             )
         }
     }

--- a/arro3-core/src/accessors/struct_field.rs
+++ b/arro3-core/src/accessors/struct_field.rs
@@ -40,7 +40,8 @@ pub(crate) fn struct_field(
         array_ref.slice(orig_array.offset(), orig_array.len()),
         field_ref.clone(),
     )
-    .to_arro3(py)?)
+    .to_arro3(py)?
+    .unbind())
 }
 
 fn get_child(array: &ArrayRef, i: usize) -> Result<(&ArrayRef, &FieldRef), ArrowError> {

--- a/arro3-core/src/constructors.rs
+++ b/arro3-core/src/constructors.rs
@@ -9,16 +9,16 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use pyo3_arrow::error::PyArrowResult;
+use pyo3_arrow::export::Arro3Array;
 use pyo3_arrow::{PyArray, PyField};
 
 #[pyfunction]
 #[pyo3(signature=(values, list_size, *, r#type=None))]
 pub(crate) fn fixed_size_list_array(
-    py: Python,
     values: PyArray,
     list_size: i32,
     r#type: Option<PyField>,
-) -> PyArrowResult<PyObject> {
+) -> PyArrowResult<Arro3Array> {
     let (values_array, values_field) = values.into_inner();
     let output_field = r#type.map(|t| t.into_inner()).unwrap_or_else(|| {
         Arc::new(Field::new(
@@ -36,17 +36,16 @@ pub(crate) fn fixed_size_list_array(
         }
     };
     let array = FixedSizeListArray::try_new(inner_field.clone(), list_size, values_array, None)?;
-    Ok(PyArray::new(Arc::new(array), output_field).to_arro3(py)?)
+    Ok(PyArray::new(Arc::new(array), output_field).into())
 }
 
 #[pyfunction]
 #[pyo3(signature=(offsets, values, *, r#type=None))]
 pub(crate) fn list_array(
-    py: Python,
     offsets: PyArray,
     values: PyArray,
     r#type: Option<PyField>,
-) -> PyArrowResult<PyObject> {
+) -> PyArrowResult<Arro3Array> {
     let (values_array, values_field) = values.into_inner();
     let (offsets_array, _) = offsets.into_inner();
     let large_offsets = match offsets_array.data_type() {
@@ -93,17 +92,16 @@ pub(crate) fn list_array(
             None,
         )?)
     };
-    Ok(PyArray::new(Arc::new(list_array), output_field).to_arro3(py)?)
+    Ok(PyArray::new(Arc::new(list_array), output_field).into())
 }
 
 #[pyfunction]
 #[pyo3(signature=(arrays, *, fields, r#type=None))]
 pub(crate) fn struct_array(
-    py: Python,
     arrays: Vec<PyArray>,
     fields: Vec<PyField>,
     r#type: Option<PyField>,
-) -> PyArrowResult<PyObject> {
+) -> PyArrowResult<Arro3Array> {
     let output_field = r#type.map(|t| t.into_inner()).unwrap_or_else(|| {
         let fields = fields
             .into_iter()
@@ -125,5 +123,5 @@ pub(crate) fn struct_array(
         .collect::<Vec<_>>();
 
     let array = StructArray::try_new(inner_fields, arrays, None)?;
-    Ok(PyArray::new(Arc::new(array), output_field).to_arro3(py)?)
+    Ok(PyArray::new(Arc::new(array), output_field).into())
 }

--- a/arro3-io/src/ipc.rs
+++ b/arro3-io/src/ipc.rs
@@ -5,6 +5,7 @@ use arrow_ipc::writer::IpcWriteOptions;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_arrow::error::PyArrowResult;
+use pyo3_arrow::export::Arro3RecordBatchReader;
 use pyo3_arrow::input::AnyRecordBatch;
 use pyo3_arrow::PyRecordBatchReader;
 
@@ -12,18 +13,18 @@ use crate::utils::{FileReader, FileWriter};
 
 /// Read an Arrow IPC file to an Arrow RecordBatchReader
 #[pyfunction]
-pub fn read_ipc(py: Python, file: FileReader) -> PyArrowResult<PyObject> {
+pub fn read_ipc(file: FileReader) -> PyArrowResult<Arro3RecordBatchReader> {
     let builder = FileReaderBuilder::new();
     let buf_file = BufReader::new(file);
     let reader = builder.build(buf_file)?;
-    Ok(PyRecordBatchReader::new(Box::new(reader)).to_arro3(py)?)
+    Ok(PyRecordBatchReader::new(Box::new(reader)).into())
 }
 
 /// Read an Arrow IPC Stream file to an Arrow RecordBatchReader
 #[pyfunction]
-pub fn read_ipc_stream(py: Python, file: FileReader) -> PyArrowResult<PyObject> {
+pub fn read_ipc_stream(file: FileReader) -> PyArrowResult<Arro3RecordBatchReader> {
     let reader = StreamReader::try_new(file, None)?;
-    Ok(PyRecordBatchReader::new(Box::new(reader)).to_arro3(py)?)
+    Ok(PyRecordBatchReader::new(Box::new(reader)).into())
 }
 
 #[allow(clippy::upper_case_acronyms)]

--- a/arro3-io/src/parquet.rs
+++ b/arro3-io/src/parquet.rs
@@ -14,6 +14,7 @@ use parquet::schema::types::ColumnPath;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3_arrow::error::PyArrowResult;
+use pyo3_arrow::export::Arro3RecordBatchReader;
 use pyo3_arrow::input::AnyRecordBatch;
 use pyo3_arrow::{PyRecordBatchReader, PyTable};
 use pyo3_object_store::PyObjectStore;
@@ -22,7 +23,7 @@ use crate::error::Arro3IoResult;
 use crate::utils::{FileReader, FileWriter};
 
 #[pyfunction]
-pub fn read_parquet(py: Python, file: FileReader) -> PyArrowResult<PyObject> {
+pub fn read_parquet(file: FileReader) -> PyArrowResult<Arro3RecordBatchReader> {
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
 
     let metadata = builder.schema().metadata().clone();
@@ -40,7 +41,7 @@ pub fn read_parquet(py: Python, file: FileReader) -> PyArrowResult<PyObject> {
     // https://docs.rs/parquet/latest/parquet/arrow/arrow_reader/struct.ParquetRecordBatchReader.html#method.schema
     // https://github.com/apache/arrow-rs/pull/5135
     let iter = Box::new(RecordBatchIterator::new(reader, arrow_schema));
-    Ok(PyRecordBatchReader::new(iter).to_arro3(py)?)
+    Ok(PyRecordBatchReader::new(iter).into())
 }
 
 #[pyfunction]

--- a/pyo3-arrow/src/array.rs
+++ b/pyo3-arrow/src/array.rs
@@ -240,12 +240,12 @@ impl PyArray {
 
     #[pyo3(signature = (dtype=None, copy=None))]
     #[allow(unused_variables)]
-    fn __array__(
-        &self,
-        py: Python,
-        dtype: Option<PyObject>,
-        copy: Option<PyObject>,
-    ) -> PyResult<PyObject> {
+    fn __array__<'py>(
+        &'py self,
+        py: Python<'py>,
+        dtype: Option<Bound<'py, PyAny>>,
+        copy: Option<Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         to_numpy(py, &self.array)
     }
 

--- a/pyo3-arrow/src/array.rs
+++ b/pyo3-arrow/src/array.rs
@@ -123,15 +123,6 @@ impl PyArray {
             .getattr(intern!(py, "array"))?
             .call1(PyTuple::new(py, vec![cloned.into_pyobject(py)?])?)
     }
-
-    pub(crate) fn to_array_pycapsules<'py>(
-        py: Python<'py>,
-        field: FieldRef,
-        array: ArrayRef,
-        requested_schema: Option<Bound<'py, PyCapsule>>,
-    ) -> PyArrowResult<Bound<'py, PyTuple>> {
-        to_array_pycapsules(py, field.clone(), &array, requested_schema)
-    }
 }
 
 impl From<ArrayRef> for PyArray {

--- a/pyo3-arrow/src/array.rs
+++ b/pyo3-arrow/src/array.rs
@@ -20,6 +20,7 @@ use pyo3::{intern, IntoPyObjectExt};
 #[cfg(feature = "buffer_protocol")]
 use crate::buffer::AnyBufferProtocol;
 use crate::error::PyArrowResult;
+use crate::export::{Arro3Array, Arro3DataType, Arro3Field};
 use crate::ffi::from_python::utils::import_array_pycapsules;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_array;
 use crate::ffi::{to_array_pycapsules, to_schema_pycapsule};
@@ -38,6 +39,7 @@ use crate::{PyDataType, PyField};
 /// Field](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrow_c_array__).
 /// In particular, storing a [FieldRef] is required to persist Arrow extension metadata through the
 /// C Data Interface.
+#[derive(Debug)]
 #[pyclass(module = "arro3.core._core", name = "Array", subclass)]
 pub struct PyArray {
     array: ArrayRef,
@@ -98,29 +100,37 @@ impl PyArray {
     /// Export to an arro3.core.Array.
     ///
     /// This requires that you depend on arro3-core from your Python package.
-    pub fn to_arro3(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_arro3<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let arro3_mod = py.import(intern!(py, "arro3.core"))?;
-        let core_obj = arro3_mod.getattr(intern!(py, "Array"))?.call_method1(
+        arro3_mod.getattr(intern!(py, "Array"))?.call_method1(
             intern!(py, "from_arrow_pycapsule"),
             self.__arrow_c_array__(py, None)?,
-        )?;
-        core_obj.into_py_any(py)
+        )
     }
 
     /// Export this to a Python `nanoarrow.Array`.
-    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_nanoarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         to_nanoarrow_array(py, &self.__arrow_c_array__(py, None)?)
     }
 
     /// Export to a pyarrow.Array
     ///
     /// Requires pyarrow >=14
-    pub fn to_pyarrow(self, py: Python) -> PyResult<PyObject> {
+    pub fn to_pyarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pyarrow_mod = py.import(intern!(py, "pyarrow"))?;
-        let pyarrow_obj = pyarrow_mod
+        let cloned = Self::new(self.array.clone(), self.field.clone());
+        pyarrow_mod
             .getattr(intern!(py, "array"))?
-            .call1(PyTuple::new(py, vec![self.into_pyobject(py)?])?)?;
-        pyarrow_obj.into_py_any(py)
+            .call1(PyTuple::new(py, vec![cloned.into_pyobject(py)?])?)
+    }
+
+    pub(crate) fn to_array_pycapsules<'py>(
+        py: Python<'py>,
+        field: FieldRef,
+        array: ArrayRef,
+        requested_schema: Option<Bound<'py, PyCapsule>>,
+    ) -> PyArrowResult<Bound<'py, PyTuple>> {
+        to_array_pycapsules(py, field.clone(), &array, requested_schema)
     }
 }
 
@@ -255,7 +265,7 @@ impl PyArray {
         &'py self,
         py: Python<'py>,
         requested_schema: Option<Bound<'py, PyCapsule>>,
-    ) -> PyArrowResult<Bound<PyTuple>> {
+    ) -> PyArrowResult<Bound<'py, PyTuple>> {
         to_array_pycapsules(py, self.field.clone(), &self.array, requested_schema)
     }
 
@@ -345,16 +355,16 @@ impl PyArray {
         Ok(Self::from_array_ref(arrow_array))
     }
 
-    fn cast(&self, py: Python, target_type: PyField) -> PyArrowResult<PyObject> {
+    fn cast(&self, target_type: PyField) -> PyArrowResult<Arro3Array> {
         let new_field = target_type.into_inner();
         let new_array = arrow::compute::cast(self.as_ref(), new_field.data_type())?;
-        Ok(PyArray::new(new_array, new_field).to_arro3(py)?)
+        Ok(PyArray::new(new_array, new_field).into())
     }
 
     #[getter]
     #[pyo3(name = "field")]
-    fn py_field(&self, py: Python) -> PyResult<PyObject> {
-        PyField::new(self.field.clone()).to_arro3(py)
+    fn py_field(&self) -> Arro3Field {
+        PyField::new(self.field.clone()).into()
     }
 
     #[getter]
@@ -368,18 +378,18 @@ impl PyArray {
     }
 
     #[pyo3(signature = (offset=0, length=None))]
-    fn slice(&self, py: Python, offset: usize, length: Option<usize>) -> PyResult<PyObject> {
+    fn slice(&self, offset: usize, length: Option<usize>) -> Arro3Array {
         let length = length.unwrap_or_else(|| self.array.len() - offset);
         let new_array = self.array.slice(offset, length);
-        PyArray::new(new_array, self.field().clone()).to_arro3(py)
+        PyArray::new(new_array, self.field().clone()).into()
     }
 
-    fn take(&self, py: Python, indices: PyArray) -> PyArrowResult<PyObject> {
+    fn take(&self, indices: PyArray) -> PyArrowResult<Arro3Array> {
         let new_array = arrow::compute::take(self.as_ref(), indices.as_ref(), None)?;
-        Ok(PyArray::new(new_array, self.field.clone()).to_arro3(py)?)
+        Ok(PyArray::new(new_array, self.field.clone()).into())
     }
 
-    fn to_numpy(&self, py: Python) -> PyResult<PyObject> {
+    fn to_numpy<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         self.__array__(py, None, None)
     }
 
@@ -394,7 +404,7 @@ impl PyArray {
     }
 
     #[getter]
-    fn r#type(&self, py: Python) -> PyResult<PyObject> {
-        PyDataType::new(self.field.data_type().clone()).to_arro3(py)
+    fn r#type(&self) -> Arro3DataType {
+        PyDataType::new(self.field.data_type().clone()).into()
     }
 }

--- a/pyo3-arrow/src/buffer.rs
+++ b/pyo3-arrow/src/buffer.rs
@@ -261,7 +261,6 @@ impl AnyBufferProtocol {
     /// - This assumes that the Python buffer is immutable. Immutability is not guaranteed by the
     ///   Python buffer protocol, so the end user must uphold this. Mutating a Python buffer could
     ///   lead to undefined behavior.
-
     // Note: in the future, maybe you should check item alignment as well?
     // https://github.com/PyO3/pyo3/blob/ce18f79d71f4d3eac54f55f7633cf08d2f57b64e/src/buffer.rs#L217-L221
     pub fn into_arrow_array(self) -> PyArrowResult<ArrayRef> {

--- a/pyo3-arrow/src/export.rs
+++ b/pyo3-arrow/src/export.rs
@@ -1,0 +1,339 @@
+/// Wrappers around objects defined in this crate to simplify returning data to `arro3-core`.
+///
+/// By default, if you return something like a `PyArray` from your Python function, it will work
+/// because `PyArray` implements `#[pyclass]`, but it will statically link the private methods
+/// defined on `PyArray` in your given version of `pyo3-arrow`.
+///
+/// This isn't ideal for a few reasons. For one, this means that the actual classes returned from
+/// multiple packages will be _different_. This also means that any updates in the latest `arro3`
+/// version won't be reflected in your exported classes.
+///
+/// Instead, because Arrow is an ABI-stable format, it's easy to _dynamically_ link the data. So we
+/// can pass Arrow data at runtime to whatever version of `arro3-core` the user has in their Python
+/// environment.
+///
+/// Because each of the objects in this module implements `[IntoPyObject]`, you can return these
+/// objects directly.
+///
+/// ```notest
+/// /// A function that will automatically return
+/// #[pyfunction]
+/// fn my_function() -> pyo3_arrow::export::Arro3Array {
+///     todo!()
+/// }
+/// ```
+///
+/// Note that this means you must require `arro3-core` as a Python dependency in the
+/// `pyproject.toml` of your Rust-Python library.
+use std::sync::Arc;
+
+use arrow_array::{RecordBatch, RecordBatchReader};
+use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::PyTuple;
+
+use crate::ffi::{to_array_pycapsules, to_schema_pycapsule};
+use crate::{
+    PyArray, PyChunkedArray, PyDataType, PyField, PyRecordBatch, PyRecordBatchReader, PyScalar,
+    PySchema, PyTable,
+};
+
+/// A wrapper around a [PyArray] that implements [IntoPyObject] to convert to a runtime-available
+/// `arro3.core.Array`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.Array` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3Array(PyArray);
+
+impl From<PyArray> for Arro3Array {
+    fn from(value: PyArray) -> Self {
+        Self(value)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3Array {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        arro3_mod.getattr(intern!(py, "Array"))?.call_method1(
+            intern!(py, "from_arrow_pycapsule"),
+            to_array_pycapsules(py, self.0.field().clone(), &self.0.array(), None)?,
+        )
+    }
+}
+
+/// A wrapper around a [PyChunkedArray] that implements [IntoPyObject] to convert to a
+/// runtime-available `arro3.core.ChunkedArray`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.ChunkedArray` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3ChunkedArray(PyChunkedArray);
+
+impl From<PyChunkedArray> for Arro3ChunkedArray {
+    fn from(value: PyChunkedArray) -> Self {
+        Self(value)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3ChunkedArray {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        todo!()
+        // let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        // arro3_mod.getattr(intern!(py, "ChunkedArray"))?.call_method1(
+        //     intern!(py, "from_arrow_pycapsule"),
+        //     PyTuple::new(py, vec![self.0.to_stream_pycapsule(py, None)?])?,
+        // )
+    }
+}
+
+/// A wrapper around a [PyField] that implements [IntoPyObject] to convert to a runtime-available
+/// `arro3.core.Field`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.Field` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3Field(PyField);
+
+impl From<PyField> for Arro3Field {
+    fn from(value: PyField) -> Self {
+        Self(value)
+    }
+}
+
+impl From<FieldRef> for Arro3Field {
+    fn from(value: FieldRef) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&Field> for Arro3Field {
+    fn from(value: &Field) -> Self {
+        Self(Arc::new(value.clone()).into())
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3Field {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        arro3_mod.getattr(intern!(py, "Field"))?.call_method1(
+            intern!(py, "from_arrow_pycapsule"),
+            PyTuple::new(py, vec![to_schema_pycapsule(py, self.0.as_ref())?])?,
+        )
+    }
+}
+
+/// A wrapper around a [PyDataType] that implements [IntoPyObject] to convert to a
+/// runtime-available `arro3.core.DataType`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.DataType` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3DataType(PyDataType);
+
+impl From<PyDataType> for Arro3DataType {
+    fn from(value: PyDataType) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DataType> for Arro3DataType {
+    fn from(value: DataType) -> Self {
+        Self(PyDataType::new(value))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3DataType {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        arro3_mod.getattr(intern!(py, "DataType"))?.call_method1(
+            intern!(py, "from_arrow_pycapsule"),
+            PyTuple::new(py, vec![to_schema_pycapsule(py, self.0.as_ref())?])?,
+        )
+    }
+}
+
+/// A wrapper around a [PyRecordBatch] that implements [IntoPyObject] to convert to a
+/// runtime-available `arro3.core.RecordBatch`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.RecordBatch` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3RecordBatch(PyRecordBatch);
+
+impl From<PyRecordBatch> for Arro3RecordBatch {
+    fn from(value: PyRecordBatch) -> Self {
+        Self(value)
+    }
+}
+
+impl From<RecordBatch> for Arro3RecordBatch {
+    fn from(value: RecordBatch) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3RecordBatch {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        todo!()
+        // let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        // arro3_mod.getattr(intern!(py, "RecordBatch"))?.call_method1(
+        //     intern!(py, "from_arrow_pycapsule"),
+        //     PyTuple::new(py, vec![self.0.to_stream_pycapsule(py, None)?])?,
+        // )
+    }
+}
+
+/// A wrapper around a [PyRecordBatchReader] that implements [IntoPyObject] to convert to a
+/// runtime-available `arro3.core.RecordBatchReader`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.RecordBatchReader` and not the one statically linked from Rust.
+pub struct Arro3RecordBatchReader(PyRecordBatchReader);
+
+impl From<PyRecordBatchReader> for Arro3RecordBatchReader {
+    fn from(value: PyRecordBatchReader) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Box<dyn RecordBatchReader + Send>> for Arro3RecordBatchReader {
+    fn from(value: Box<dyn RecordBatchReader + Send>) -> Self {
+        Self(PyRecordBatchReader::new(value))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3RecordBatchReader {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        todo!()
+        // let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        // arro3_mod.getattr(intern!(py, "RecordBatchReader"))?.call_method1(
+        //     intern!(py, "from_arrow_pycapsule"),
+        //     PyTuple::new(py, vec![self.0.to_stream_pycapsule(py, None)?])?,
+        // )
+    }
+}
+
+/// A wrapper around a [PyScalar] that implements [IntoPyObject] to convert to a
+/// runtime-available `arro3.core.Scalar`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.Scalar` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3Scalar(PyScalar);
+
+impl From<PyScalar> for Arro3Scalar {
+    fn from(value: PyScalar) -> Self {
+        Self(value)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3Scalar {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        todo!()
+        // let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        // arro3_mod.getattr(intern!(py, "Schema"))?.call_method1(
+        //     intern!(py, "from_arrow_pycapsule"),
+        //     PyTuple::new(py, vec![to_schema_pycapsule(py, self.0.as_ref())?])?,
+        // )
+    }
+}
+
+/// A wrapper around a [PySchema] that implements [IntoPyObject] to convert to a
+/// runtime-available `arro3.core.Schema`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.Schema` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3Schema(PySchema);
+
+impl From<PySchema> for Arro3Schema {
+    fn from(value: PySchema) -> Self {
+        Self(value)
+    }
+}
+
+impl From<SchemaRef> for Arro3Schema {
+    fn from(value: SchemaRef) -> Self {
+        Self(PySchema::new(value))
+    }
+}
+
+impl From<Schema> for Arro3Schema {
+    fn from(value: Schema) -> Self {
+        Self(PySchema::new(Arc::new(value)))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3Schema {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        arro3_mod.getattr(intern!(py, "Schema"))?.call_method1(
+            intern!(py, "from_arrow_pycapsule"),
+            PyTuple::new(py, vec![to_schema_pycapsule(py, self.0.as_ref())?])?,
+        )
+    }
+}
+
+/// A wrapper around a [PyTable] that implements [IntoPyObject] to convert to a
+/// runtime-available `arro3.core.Table`.
+///
+/// This ensures that we return data with the **user's** runtime-provided (dynamically-linked)
+/// `arro3.core.Table` and not the one statically linked from Rust.
+#[derive(Debug)]
+pub struct Arro3Table(PyTable);
+
+impl From<PyTable> for Arro3Table {
+    fn from(value: PyTable) -> Self {
+        Self(value)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Arro3Table {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        let (batches, schema) = self.0.into_inner();
+        let capsule = PyTable::to_stream_pycapsule(py, batches, schema, None)?;
+        arro3_mod.getattr(intern!(py, "Table"))?.call_method1(
+            intern!(py, "from_arrow_pycapsule"),
+            PyTuple::new(py, vec![capsule])?,
+        )
+    }
+}

--- a/pyo3-arrow/src/ffi/to_python/nanoarrow.rs
+++ b/pyo3-arrow/src/ffi/to_python/nanoarrow.rs
@@ -1,25 +1,31 @@
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyTuple};
-use pyo3::{intern, IntoPyObjectExt};
 
-pub fn to_nanoarrow_schema(py: Python, capsule: &Bound<'_, PyCapsule>) -> PyResult<PyObject> {
+pub fn to_nanoarrow_schema<'py>(
+    py: Python<'py>,
+    capsule: &Bound<'py, PyCapsule>,
+) -> PyResult<Bound<'py, PyAny>> {
     let na_mod = py.import(intern!(py, "nanoarrow"))?;
-    let pyarrow_obj = na_mod
+    na_mod
         .getattr(intern!(py, "Schema"))?
-        .call1(PyTuple::new(py, vec![capsule])?)?;
-    pyarrow_obj.into_py_any(py)
+        .call1(PyTuple::new(py, vec![capsule])?)
 }
 
-pub fn to_nanoarrow_array(py: Python, capsules: &Bound<'_, PyTuple>) -> PyResult<PyObject> {
+pub fn to_nanoarrow_array<'py>(
+    py: Python<'py>,
+    capsules: &Bound<'py, PyTuple>,
+) -> PyResult<Bound<'py, PyAny>> {
     let na_mod = py.import(intern!(py, "nanoarrow"))?;
-    let pyarrow_obj = na_mod.getattr(intern!(py, "Array"))?.call1(capsules)?;
-    pyarrow_obj.into_py_any(py)
+    na_mod.getattr(intern!(py, "Array"))?.call1(capsules)
 }
 
-pub fn to_nanoarrow_array_stream(py: Python, capsule: &Bound<'_, PyCapsule>) -> PyResult<PyObject> {
+pub fn to_nanoarrow_array_stream<'py>(
+    py: Python<'py>,
+    capsule: &Bound<'py, PyCapsule>,
+) -> PyResult<Bound<'py, PyAny>> {
     let na_mod = py.import(intern!(py, "nanoarrow"))?;
-    let pyarrow_obj = na_mod
+    na_mod
         .getattr(intern!(py, "ArrayStream"))?
-        .call1(PyTuple::new(py, vec![capsule])?)?;
-    pyarrow_obj.into_py_any(py)
+        .call1(PyTuple::new(py, vec![capsule])?)
 }

--- a/pyo3-arrow/src/interop/numpy/to_numpy.rs
+++ b/pyo3-arrow/src/interop/numpy/to_numpy.rs
@@ -51,12 +51,11 @@ pub fn to_numpy<'py>(py: Python<'py>, arr: &'py dyn Array) -> PyResult<Bound<'py
             let numpy_mod = py.import(intern!(py, "numpy"))?;
             let kwargs = PyDict::new(py);
             kwargs.set_item("dtype", numpy_mod.getattr(intern!(py, "object_"))?)?;
-            let np_arr = numpy_mod.call_method(
+            numpy_mod.call_method(
                 intern!(py, "array"),
                 PyTuple::new(py, vec![py_list])?,
                 Some(&kwargs),
-            )?;
-            np_arr
+            )?
         }
         DataType::LargeBinary => {
             let mut py_bytes = Vec::with_capacity(arr.len());
@@ -67,12 +66,11 @@ pub fn to_numpy<'py>(py: Python<'py>, arr: &'py dyn Array) -> PyResult<Bound<'py
             let numpy_mod = py.import(intern!(py, "numpy"))?;
             let kwargs = PyDict::new(py);
             kwargs.set_item("dtype", numpy_mod.getattr(intern!(py, "object_"))?)?;
-            let np_arr = numpy_mod.call_method(
+            numpy_mod.call_method(
                 intern!(py, "array"),
                 PyTuple::new(py, vec![py_list])?,
                 Some(&kwargs),
-            )?;
-            np_arr
+            )?
         }
         DataType::Utf8 => {
             let mut py_bytes = Vec::with_capacity(arr.len());
@@ -83,12 +81,11 @@ pub fn to_numpy<'py>(py: Python<'py>, arr: &'py dyn Array) -> PyResult<Bound<'py
             let numpy_mod = py.import(intern!(py, "numpy"))?;
             let kwargs = PyDict::new(py);
             kwargs.set_item("dtype", numpy_mod.getattr(intern!(py, "object_"))?)?;
-            let np_arr = numpy_mod.call_method(
+            numpy_mod.call_method(
                 intern!(py, "array"),
                 PyTuple::new(py, vec![py_list])?,
                 Some(&kwargs),
-            )?;
-            np_arr
+            )?
         }
         DataType::LargeUtf8 => {
             let mut py_bytes = Vec::with_capacity(arr.len());
@@ -99,12 +96,11 @@ pub fn to_numpy<'py>(py: Python<'py>, arr: &'py dyn Array) -> PyResult<Bound<'py
             let numpy_mod = py.import(intern!(py, "numpy"))?;
             let kwargs = PyDict::new(py);
             kwargs.set_item("dtype", numpy_mod.getattr(intern!(py, "object_"))?)?;
-            let np_arr = numpy_mod.call_method(
+            numpy_mod.call_method(
                 intern!(py, "array"),
                 PyTuple::new(py, vec![py_list])?,
                 Some(&kwargs),
-            )?;
-            np_arr
+            )?
         }
         dt => {
             return Err(PyNotImplementedError::new_err(format!(
@@ -117,7 +113,7 @@ pub fn to_numpy<'py>(py: Python<'py>, arr: &'py dyn Array) -> PyResult<Bound<'py
 
 pub fn chunked_to_numpy<'py>(
     py: Python<'py>,
-    arrs: &'py [&dyn Array],
+    arrs: Vec<&'py dyn Array>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let py_arrays = arrs
         .iter()

--- a/pyo3-arrow/src/lib.rs
+++ b/pyo3-arrow/src/lib.rs
@@ -8,6 +8,7 @@ pub mod buffer;
 mod chunked;
 mod datatypes;
 pub mod error;
+pub mod export;
 pub mod ffi;
 mod field;
 pub mod input;

--- a/pyo3-arrow/src/record_batch.rs
+++ b/pyo3-arrow/src/record_batch.rs
@@ -12,6 +12,7 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 use pyo3::{intern, IntoPyObjectExt};
 
 use crate::error::PyArrowResult;
+use crate::export::{Arro3Array, Arro3Field, Arro3RecordBatch, Arro3Schema};
 use crate::ffi::from_python::utils::import_array_pycapsules;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_array;
 use crate::ffi::to_python::to_array_pycapsules;
@@ -81,19 +82,16 @@ impl PyRecordBatch {
     }
 
     /// Export this to a Python `arro3.core.RecordBatch`.
-    pub fn to_arro3(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_arro3<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let arro3_mod = py.import(intern!(py, "arro3.core"))?;
-        let core_obj = arro3_mod
-            .getattr(intern!(py, "RecordBatch"))?
-            .call_method1(
-                intern!(py, "from_arrow_pycapsule"),
-                self.__arrow_c_array__(py, None)?,
-            )?;
-        core_obj.into_py_any(py)
+        arro3_mod.getattr(intern!(py, "RecordBatch"))?.call_method1(
+            intern!(py, "from_arrow_pycapsule"),
+            self.__arrow_c_array__(py, None)?,
+        )
     }
 
     /// Export this to a Python `nanoarrow.Array`.
-    pub fn to_nanoarrow(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_nanoarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         to_nanoarrow_array(py, &self.__arrow_c_array__(py, None)?)
     }
 
@@ -185,8 +183,8 @@ impl PyRecordBatch {
         self.0 == other.0
     }
 
-    fn __getitem__(&self, py: Python, key: FieldIndexInput) -> PyResult<PyObject> {
-        self.column(py, key)
+    fn __getitem__(&self, key: FieldIndexInput) -> PyResult<Arro3Array> {
+        self.column(key)
     }
 
     fn __repr__(&self) -> String {
@@ -272,11 +270,10 @@ impl PyRecordBatch {
 
     fn add_column(
         &self,
-        py: Python,
         i: usize,
         field: NameOrField,
         column: PyArray,
-    ) -> PyArrowResult<PyObject> {
+    ) -> PyArrowResult<Arro3RecordBatch> {
         let mut fields = self.0.schema_ref().fields().to_vec();
         fields.insert(i, field.into_field(column.field()));
         let schema = Schema::new_with_metadata(fields, self.0.schema_ref().metadata().clone());
@@ -285,15 +282,14 @@ impl PyRecordBatch {
         arrays.insert(i, column.array().clone());
 
         let new_rb = RecordBatch::try_new(schema.into(), arrays)?;
-        Ok(PyRecordBatch::new(new_rb).to_arro3(py)?)
+        Ok(PyRecordBatch::new(new_rb).into())
     }
 
     fn append_column(
         &self,
-        py: Python,
         field: NameOrField,
         column: PyArray,
-    ) -> PyArrowResult<PyObject> {
+    ) -> PyArrowResult<Arro3RecordBatch> {
         let mut fields = self.0.schema_ref().fields().to_vec();
         fields.push(field.into_field(column.field()));
         let schema = Schema::new_with_metadata(fields, self.0.schema_ref().metadata().clone());
@@ -302,14 +298,14 @@ impl PyRecordBatch {
         arrays.push(column.array().clone());
 
         let new_rb = RecordBatch::try_new(schema.into(), arrays)?;
-        Ok(PyRecordBatch::new(new_rb).to_arro3(py)?)
+        Ok(PyRecordBatch::new(new_rb).into())
     }
 
-    fn column(&self, py: Python, i: FieldIndexInput) -> PyResult<PyObject> {
+    fn column(&self, i: FieldIndexInput) -> PyResult<Arro3Array> {
         let column_index = i.into_position(self.0.schema_ref())?;
         let field = self.0.schema().field(column_index).clone();
         let array = self.0.column(column_index).clone();
-        PyArray::new(array, field.into()).to_arro3(py)
+        Ok(PyArray::new(array, field.into()).into())
     }
 
     #[getter]
@@ -323,9 +319,9 @@ impl PyRecordBatch {
     }
 
     #[getter]
-    fn columns(&self, py: Python) -> PyResult<Vec<PyObject>> {
+    fn columns(&self) -> PyResult<Vec<Arro3Array>> {
         (0..self.num_columns())
-            .map(|i| self.column(py, FieldIndexInput::Position(i)))
+            .map(|i| self.column(FieldIndexInput::Position(i)))
             .collect()
     }
 
@@ -333,10 +329,10 @@ impl PyRecordBatch {
         self.0 == other.0
     }
 
-    fn field(&self, py: Python, i: FieldIndexInput) -> PyResult<PyObject> {
+    fn field(&self, i: FieldIndexInput) -> PyResult<Arro3Field> {
         let schema_ref = self.0.schema_ref();
         let field = schema_ref.field(i.into_position(schema_ref)?);
-        PyField::new(field.clone().into()).to_arro3(py)
+        Ok(PyField::new(field.clone().into()).into())
     }
 
     #[getter]
@@ -354,30 +350,28 @@ impl PyRecordBatch {
         self.0.num_rows()
     }
 
-    fn remove_column(&self, py: Python, i: usize) -> PyResult<PyObject> {
+    fn remove_column(&self, i: usize) -> Arro3RecordBatch {
         let mut rb = self.0.clone();
         rb.remove_column(i);
-        PyRecordBatch::new(rb).to_arro3(py)
+        PyRecordBatch::new(rb).into()
     }
 
     #[getter]
-    fn schema(&self, py: Python) -> PyResult<PyObject> {
-        PySchema::new(self.0.schema()).to_arro3(py)
+    fn schema(&self) -> Arro3Schema {
+        self.0.schema().into()
     }
 
-    fn select(&self, py: Python, columns: SelectIndices) -> PyArrowResult<PyObject> {
+    fn select(&self, columns: SelectIndices) -> PyArrowResult<Arro3RecordBatch> {
         let positions = columns.into_positions(self.0.schema_ref().fields())?;
-        let new_rb = self.0.project(&positions)?;
-        Ok(PyRecordBatch::new(new_rb).to_arro3(py)?)
+        Ok(self.0.project(&positions)?.into())
     }
 
     fn set_column(
         &self,
-        py: Python,
         i: usize,
         field: NameOrField,
         column: PyArray,
-    ) -> PyArrowResult<PyObject> {
+    ) -> PyArrowResult<Arro3RecordBatch> {
         let mut fields = self.0.schema_ref().fields().to_vec();
         fields[i] = field.into_field(column.field());
         let schema = Schema::new_with_metadata(fields, self.0.schema_ref().metadata().clone());
@@ -385,8 +379,7 @@ impl PyRecordBatch {
         let mut arrays = self.0.columns().to_vec();
         arrays[i] = column.array().clone();
 
-        let new_rb = RecordBatch::try_new(schema.into(), arrays)?;
-        Ok(PyRecordBatch::new(new_rb).to_arro3(py)?)
+        Ok(RecordBatch::try_new(schema.into(), arrays)?.into())
     }
 
     #[getter]
@@ -395,26 +388,26 @@ impl PyRecordBatch {
     }
 
     #[pyo3(signature = (offset=0, length=None))]
-    fn slice(&self, py: Python, offset: usize, length: Option<usize>) -> PyResult<PyObject> {
+    fn slice(&self, offset: usize, length: Option<usize>) -> Arro3RecordBatch {
         let length = length.unwrap_or_else(|| self.num_rows() - offset);
-        PyRecordBatch::new(self.0.slice(offset, length)).to_arro3(py)
+        self.0.slice(offset, length).into()
     }
 
-    fn take(&self, py: Python, indices: PyArray) -> PyArrowResult<PyObject> {
+    fn take(&self, indices: PyArray) -> PyArrowResult<Arro3RecordBatch> {
         let new_batch = take_record_batch(self.as_ref(), indices.as_ref())?;
-        Ok(PyRecordBatch::new(new_batch).to_arro3(py)?)
+        Ok(new_batch.into())
     }
 
-    fn to_struct_array(&self, py: Python) -> PyArrowResult<PyObject> {
+    fn to_struct_array(&self) -> Arro3Array {
         let struct_array: StructArray = self.0.clone().into();
         let field = Field::new_struct("", self.0.schema_ref().fields().clone(), false)
             .with_metadata(self.0.schema_ref().metadata.clone());
-        Ok(PyArray::new(Arc::new(struct_array), field.into()).to_arro3(py)?)
+        PyArray::new(Arc::new(struct_array), field.into()).into()
     }
 
-    fn with_schema(&self, py: Python, schema: PySchema) -> PyArrowResult<PyObject> {
+    fn with_schema(&self, schema: PySchema) -> PyArrowResult<Arro3RecordBatch> {
         let new_schema = schema.into_inner();
         let new_batch = RecordBatch::try_new(new_schema.clone(), self.0.columns().to_vec())?;
-        Ok(PyRecordBatch::new(new_batch).to_arro3(py)?)
+        Ok(new_batch.into())
     }
 }

--- a/pyo3-arrow/src/scalar.rs
+++ b/pyo3-arrow/src/scalar.rs
@@ -87,13 +87,12 @@ impl PyScalar {
     /// Export to an arro3.core.Scalar.
     ///
     /// This requires that you depend on arro3-core from your Python package.
-    pub fn to_arro3(&self, py: Python) -> PyResult<PyObject> {
+    pub fn to_arro3<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let arro3_mod = py.import(intern!(py, "arro3.core"))?;
-        let core_obj = arro3_mod.getattr(intern!(py, "Scalar"))?.call_method1(
+        arro3_mod.getattr(intern!(py, "Scalar"))?.call_method1(
             intern!(py, "from_arrow_pycapsule"),
             self.__arrow_c_array__(py, None)?,
-        )?;
-        core_obj.into_py_any(py)
+        )
     }
 }
 


### PR DESCRIPTION
- Avoid returning `PyObject`, and prefer `Bound<'py, PyAny>` instead. 
	
	For a long time I didn't really understand the difference between `PyObject` and `Bound<'py, PyAny>`. But recently I've learned that the former is like a "bare" `PyAny` while the latter is `PyAny` _with_ an associated `py: Python` token. That means you can do Python operations without needing to separately acquire the GIL. 

	It's preferable to return `Bound`, because that's what calls into Python return. It works nicer with the `IntoPyObject` trait. And it's easy to call `.unbind()` to get a `Py<PyAny>` (a `PyObject`).

- This also adds wrapper types to simplify export to arro3. 

	Now that we're using pyo3 0.23, there's a new [IntoPyObject trait](https://pyo3.rs/v0.23.3/migration.html#new-intopyobject-trait-unifies-to-python-conversions). This is a lot nicer than the previous `IntoPy` trait, because it allows for fallible conversions. So we can call `to_arro3()` from within the `IntoPyObject` trait impl. And e.g. if `arro3.core` isn't available, it'll correctly error.

	These wrapper types also nudge people toward the right choice: to dynamically pass data to the user's runtime instance of `arro3.core`.