### PR TITLE
Fix building aarch64 linux wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,14 +58,6 @@ jobs:
       - name: Install Python versions
         run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
 
-      - name: Add aarch64
-        if: ${{ matrix.platform.target == 'aarch64' }}
-        run: |
-          sudo apt-get install musl-tools clang llvm -y
-          echo CC_aarch64_unknown_linux_musl=clang >> $GITHUB_ENV
-          echo AR_aarch64_unknown_linux_musl=llvm-ar >> $GITHUB_ENV
-          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"' >> $GITHUB_ENV
-
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Add aarch64
         if: ${{ matrix.platform.target }} == "aarch64"
         run: |
-          apt-get install musl-tools clang llvm -y
+          sudo apt-get install musl-tools clang llvm -y
           echo CC_aarch64_unknown_linux_musl=clang >> $GITHUB_ENV
           echo AR_aarch64_unknown_linux_musl=llvm-ar >> $GITHUB_ENV
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"' >> $GITHUB_ENV

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   linux:
@@ -28,7 +28,6 @@ jobs:
             target: x86_64
           - runner: ubuntu-latest
             target: x86
-          # Need to fix ring compilation: https://github.com/briansmith/ring/issues/1414#issuecomment-1055177218
           - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest
@@ -52,6 +51,14 @@ jobs:
 
       - name: Install Python versions
         run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+
+      - name: Add aarch64
+        if: ${{ matrix.platform.target }} == "aarch64"
+        run: |
+          apt-get install musl-tools clang llvm -y
+          echo CC_aarch64_unknown_linux_musl=clang >> $GITHUB_ENV
+          echo AR_aarch64_unknown_linux_musl=llvm-ar >> $GITHUB_ENV
+          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"' >> $GITHUB_ENV
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,16 +26,22 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64
+            manylinux: auto
           - runner: ubuntu-latest
             target: x86
+            manylinux: auto
           - runner: ubuntu-latest
             target: aarch64
+            manylinux: "2_24"
           - runner: ubuntu-latest
             target: armv7
+            manylinux: auto
           - runner: ubuntu-latest
             target: s390x
+            manylinux: auto
           - runner: ubuntu-latest
             target: ppc64le
+            manylinux: auto
         module:
           - arro3-core
           - arro3-compute
@@ -68,7 +74,7 @@ jobs:
           # maturin to find the executable. --find-interpreter did not find it.
           args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
           sccache: "true"
-          manylinux: auto
+          manylinux: ${{ matrix.platform.manylinux }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
             manylinux: auto
           - runner: ubuntu-latest
             target: aarch64
-            manylinux: "2_24"
+            manylinux: "2_28"
           - runner: ubuntu-latest
             target: armv7
             manylinux: auto

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,9 +7,9 @@ name: Build wheels
 
 on:
   push:
-    tags:
-      - "py-v*"
-  workflow_dispatch:
+  #   tags:
+  #     - "py-v*"
+  # workflow_dispatch:
 
 permissions:
   contents: read
@@ -29,8 +29,8 @@ jobs:
           - runner: ubuntu-latest
             target: x86
           # Need to fix ring compilation: https://github.com/briansmith/ring/issues/1414#issuecomment-1055177218
-          # - runner: ubuntu-latest
-          #   target: aarch64
+          - runner: ubuntu-latest
+            target: aarch64
           - runner: ubuntu-latest
             target: armv7
           - runner: ubuntu-latest
@@ -69,116 +69,137 @@ jobs:
           name: wheels-linux-${{ matrix.platform.target }}-${{ matrix.module }}
           path: dist
 
-  musllinux:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-latest
-            target: x86_64
-          - runner: ubuntu-latest
-            target: x86
-          - runner: ubuntu-latest
-            target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
-        module:
-          - arro3-core
-          - arro3-compute
-          - arro3-io
-    steps:
-      - uses: actions/checkout@v4
+  # musllinux:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: ubuntu-latest
+  #           target: x86_64
+  #         - runner: ubuntu-latest
+  #           target: x86
+  #         - runner: ubuntu-latest
+  #           target: aarch64
+  #         - runner: ubuntu-latest
+  #           target: armv7
+  #       module:
+  #         - arro3-core
+  #         - arro3-compute
+  #         - arro3-io
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          version: "0.4.x"
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v3
+  #       with:
+  #         enable-cache: true
+  #         version: "0.4.x"
 
-      - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+  #     - name: Install Python versions
+  #       run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
-          sccache: "true"
-          manylinux: musllinux_1_2
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-musllinux-${{ matrix.platform.target }}-${{ matrix.module }}
-          path: dist
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
+  #         sccache: "true"
+  #         manylinux: musllinux_1_2
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-musllinux-${{ matrix.platform.target }}-${{ matrix.module }}
+  #         path: dist
 
-  windows:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-        module:
-          - arro3-core
-          - arro3-compute
-          - arro3-io
-    steps:
-      - uses: actions/checkout@v4
+  # windows:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: windows-latest
+  #           target: x64
+  #       module:
+  #         - arro3-core
+  #         - arro3-compute
+  #         - arro3-io
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.13
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: 3.13
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path ${{ matrix.module }}/Cargo.toml
-          sccache: "true"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}-${{ matrix.module }}
-          path: dist
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path ${{ matrix.module }}/Cargo.toml
+  #         sccache: "true"
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-windows-${{ matrix.platform.target }}-${{ matrix.module }}
+  #         path: dist
 
-  macos:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: macos-13
-            target: x86_64
-          - runner: macos-14
-            target: aarch64
-        module:
-          - arro3-core
-          - arro3-compute
-          - arro3-io
-    steps:
-      - uses: actions/checkout@v4
+  # macos:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: macos-13
+  #           target: x86_64
+  #         - runner: macos-14
+  #           target: aarch64
+  #       module:
+  #         - arro3-core
+  #         - arro3-compute
+  #         - arro3-io
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          version: "0.4.x"
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v3
+  #       with:
+  #         enable-cache: true
+  #         version: "0.4.x"
 
-      - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+  #     - name: Install Python versions
+  #       run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
-          sccache: "true"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}-${{ matrix.module }}
-          path: dist
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
+  #         sccache: "true"
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-macos-${{ matrix.platform.target }}-${{ matrix.module }}
+  #         path: dist
 
-  # sdist:
+  # # sdist:
+  # #   runs-on: ubuntu-latest
+  # #   strategy:
+  # #     matrix:
+  # #       module:
+  # #         - arro3-core
+  # #         - arro3-compute
+  # #         - arro3-io
+  # #   steps:
+  # #     - uses: actions/checkout@v4
+  # #     - name: Build sdist
+  # #       uses: PyO3/maturin-action@v1
+  # #       with:
+  # #         command: sdist
+  # #         args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
+  # #     - name: Upload sdist
+  # #       uses: actions/upload-artifact@v4
+  # #       with:
+  # #         name: wheels-sdist-${{ matrix.module }}
+  # #         path: dist
+
+  # release:
   #   runs-on: ubuntu-latest
   #   strategy:
   #     matrix:
@@ -186,47 +207,26 @@ jobs:
   #         - arro3-core
   #         - arro3-compute
   #         - arro3-io
+  #   name: Release
+  #   environment:
+  #     name: release
+  #     url: https://pypi.org/p/${{ matrix.module }}
+  #   permissions:
+  #     # IMPORTANT: this permission is mandatory for trusted publishing
+  #     id-token: write
+  #   if: startsWith(github.ref, 'refs/tags/')
+  #   needs: [linux, windows, macos]
   #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Build sdist
-  #       uses: PyO3/maturin-action@v1
+  #     - uses: actions/download-artifact@v4
   #       with:
-  #         command: sdist
-  #         args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
-  #     - name: Upload sdist
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-sdist-${{ matrix.module }}
+  #         pattern: wheels-*-${{ matrix.module }}
+  #         merge-multiple: true
   #         path: dist
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: 3.8
 
-  release:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        module:
-          - arro3-core
-          - arro3-compute
-          - arro3-io
-    name: Release
-    environment:
-      name: release
-      url: https://pypi.org/p/${{ matrix.module }}
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [linux, windows, macos]
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: wheels-*-${{ matrix.module }}
-          merge-multiple: true
-          path: dist
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  #     - uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
         run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
 
       - name: Add aarch64
-        if: ${{ matrix.platform.target }} == "aarch64"
+        if: ${{ matrix.platform.target == 'aarch64' }}
         run: |
           sudo apt-get install musl-tools clang llvm -y
           echo CC_aarch64_unknown_linux_musl=clang >> $GITHUB_ENV

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,16 +7,16 @@ name: Build wheels
 
 on:
   push:
-  #   tags:
-  #     - "py-v*"
-  # workflow_dispatch:
+    tags:
+      - "py-v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   linux:
@@ -74,137 +74,116 @@ jobs:
           name: wheels-linux-${{ matrix.platform.target }}-${{ matrix.module }}
           path: dist
 
-  # musllinux:
-  #   runs-on: ${{ matrix.platform.runner }}
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - runner: ubuntu-latest
-  #           target: x86_64
-  #         - runner: ubuntu-latest
-  #           target: x86
-  #         - runner: ubuntu-latest
-  #           target: aarch64
-  #         - runner: ubuntu-latest
-  #           target: armv7
-  #       module:
-  #         - arro3-core
-  #         - arro3-compute
-  #         - arro3-io
-  #   steps:
-  #     - uses: actions/checkout@v4
+  musllinux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: x86
+          - runner: ubuntu-latest
+            target: aarch64
+          - runner: ubuntu-latest
+            target: armv7
+        module:
+          - arro3-core
+          - arro3-compute
+          - arro3-io
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Install uv
-  #       uses: astral-sh/setup-uv@v3
-  #       with:
-  #         enable-cache: true
-  #         version: "0.4.x"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          version: "0.4.x"
 
-  #     - name: Install Python versions
-  #       run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+      - name: Install Python versions
+        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
 
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.platform.target }}
-  #         args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
-  #         sccache: "true"
-  #         manylinux: musllinux_1_2
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-musllinux-${{ matrix.platform.target }}-${{ matrix.module }}
-  #         path: dist
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
+          sccache: "true"
+          manylinux: musllinux_1_2
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-musllinux-${{ matrix.platform.target }}-${{ matrix.module }}
+          path: dist
 
-  # windows:
-  #   runs-on: ${{ matrix.platform.runner }}
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - runner: windows-latest
-  #           target: x64
-  #       module:
-  #         - arro3-core
-  #         - arro3-compute
-  #         - arro3-io
-  #   steps:
-  #     - uses: actions/checkout@v4
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+        module:
+          - arro3-core
+          - arro3-compute
+          - arro3-io
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: 3.13
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
 
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.platform.target }}
-  #         args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path ${{ matrix.module }}/Cargo.toml
-  #         sccache: "true"
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-windows-${{ matrix.platform.target }}-${{ matrix.module }}
-  #         path: dist
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path ${{ matrix.module }}/Cargo.toml
+          sccache: "true"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}-${{ matrix.module }}
+          path: dist
 
-  # macos:
-  #   runs-on: ${{ matrix.platform.runner }}
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - runner: macos-13
-  #           target: x86_64
-  #         - runner: macos-14
-  #           target: aarch64
-  #       module:
-  #         - arro3-core
-  #         - arro3-compute
-  #         - arro3-io
-  #   steps:
-  #     - uses: actions/checkout@v4
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-13
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+        module:
+          - arro3-core
+          - arro3-compute
+          - arro3-io
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Install uv
-  #       uses: astral-sh/setup-uv@v3
-  #       with:
-  #         enable-cache: true
-  #         version: "0.4.x"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          version: "0.4.x"
 
-  #     - name: Install Python versions
-  #       run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+      - name: Install Python versions
+        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
 
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.platform.target }}
-  #         args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
-  #         sccache: "true"
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-macos-${{ matrix.platform.target }}-${{ matrix.module }}
-  #         path: dist
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path ${{ matrix.module }}/Cargo.toml
+          sccache: "true"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}-${{ matrix.module }}
+          path: dist
 
-  # # sdist:
-  # #   runs-on: ubuntu-latest
-  # #   strategy:
-  # #     matrix:
-  # #       module:
-  # #         - arro3-core
-  # #         - arro3-compute
-  # #         - arro3-io
-  # #   steps:
-  # #     - uses: actions/checkout@v4
-  # #     - name: Build sdist
-  # #       uses: PyO3/maturin-action@v1
-  # #       with:
-  # #         command: sdist
-  # #         args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
-  # #     - name: Upload sdist
-  # #       uses: actions/upload-artifact@v4
-  # #       with:
-  # #         name: wheels-sdist-${{ matrix.module }}
-  # #         path: dist
-
-  # release:
+  # sdist:
   #   runs-on: ubuntu-latest
   #   strategy:
   #     matrix:
@@ -212,26 +191,47 @@ jobs:
   #         - arro3-core
   #         - arro3-compute
   #         - arro3-io
-  #   name: Release
-  #   environment:
-  #     name: release
-  #     url: https://pypi.org/p/${{ matrix.module }}
-  #   permissions:
-  #     # IMPORTANT: this permission is mandatory for trusted publishing
-  #     id-token: write
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #   needs: [linux, windows, macos]
   #   steps:
-  #     - uses: actions/download-artifact@v4
+  #     - uses: actions/checkout@v4
+  #     - name: Build sdist
+  #       uses: PyO3/maturin-action@v1
   #       with:
-  #         pattern: wheels-*-${{ matrix.module }}
-  #         merge-multiple: true
+  #         command: sdist
+  #         args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
+  #     - name: Upload sdist
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-sdist-${{ matrix.module }}
   #         path: dist
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: 3.8
 
-  #     - uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module:
+          - arro3-core
+          - arro3-compute
+          - arro3-io
+    name: Release
+    environment:
+      name: release
+      url: https://pypi.org/p/${{ matrix.module }}
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [linux, windows, macos]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*-${{ matrix.module }}
+          merge-multiple: true
+          path: dist
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This is the changelog for arro3. pyo3-arrow has a separate changelog.
 
+## [0.4.5] - 2024-12-16
+
+### Bug fixes :bug:
+
+- Build wheels for linux aarch64. https://github.com/kylebarron/arro3/pull/277
+
 ## [0.4.4] - 2024-12-09
 
 ### Bug fixes :bug:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "arro3-compute"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "arro3-core"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "arro3-io"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 # Package version for arro3-*, not for pyo3-arrow
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2021"
 homepage = "https://kylebarron.dev/arro3"


### PR DESCRIPTION
Closes https://github.com/kylebarron/arro3/issues/276. 

The core issue is that ring (used by rustls) doesn't build automatically (at least with manylinux auto) for linux aarch64.

This PR changes the manylinux version for aarch64 to be manylinux_2_28.

Ref https://github.com/PyO3/maturin-action/issues/278, https://github.com/PyO3/maturin-action/issues/222