### PR TITLE
Use 2_24 for aarch64 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
             manylinux: auto
           - runner: ubuntu-latest
             target: aarch64
-            manylinux: "2_28"
+            manylinux: "2_24"
           - runner: ubuntu-latest
             target: armv7
             manylinux: auto


### PR DESCRIPTION
Ref https://github.com/PyO3/maturin-action/issues/278#issuecomment-2555576928