### PR TITLE
Add frozen parameter to pyclass macro

### DIFF
--- a/pyo3-arrow/src/array.rs
+++ b/pyo3-arrow/src/array.rs
@@ -40,7 +40,7 @@ use crate::{PyDataType, PyField};
 /// In particular, storing a [FieldRef] is required to persist Arrow extension metadata through the
 /// C Data Interface.
 #[derive(Debug)]
-#[pyclass(module = "arro3.core._core", name = "Array", subclass)]
+#[pyclass(module = "arro3.core._core", name = "Array", subclass, frozen)]
 pub struct PyArray {
     array: ArrayRef,
     field: FieldRef,

--- a/pyo3-arrow/src/buffer.rs
+++ b/pyo3-arrow/src/buffer.rs
@@ -41,7 +41,7 @@ use crate::PyArray;
 /// The Python buffer protocol is implemented on this buffer to enable zero-copy data transfer of
 /// the core buffer into Python. This allows for zero-copy data sharing with numpy via
 /// `numpy.frombuffer`.
-#[pyclass(module = "arro3.core._core", name = "Buffer", subclass)]
+#[pyclass(module = "arro3.core._core", name = "Buffer", subclass, frozen)]
 pub struct PyArrowBuffer(Buffer);
 
 impl AsRef<Buffer> for PyArrowBuffer {
@@ -87,7 +87,7 @@ impl PyArrowBuffer {
     /// This is taken from opendal:
     /// https://github.com/apache/opendal/blob/d001321b0f9834bc1e2e7d463bcfdc3683e968c9/bindings/python/src/utils.rs#L51-L72
     unsafe fn __getbuffer__(
-        slf: PyRefMut<Self>,
+        slf: PyRef<Self>,
         view: *mut ffi::Py_buffer,
         flags: c_int,
     ) -> PyResult<()> {

--- a/pyo3-arrow/src/chunked.rs
+++ b/pyo3-arrow/src/chunked.rs
@@ -25,7 +25,7 @@ use crate::{PyArray, PyDataType, PyField, PyScalar};
 ///
 /// This is a wrapper around a [FieldRef] and a `Vec` of [ArrayRef].
 #[derive(Debug)]
-#[pyclass(module = "arro3.core._core", name = "ChunkedArray", subclass)]
+#[pyclass(module = "arro3.core._core", name = "ChunkedArray", subclass, frozen)]
 pub struct PyChunkedArray {
     chunks: Vec<ArrayRef>,
     field: FieldRef,

--- a/pyo3-arrow/src/datatypes.rs
+++ b/pyo3-arrow/src/datatypes.rs
@@ -32,7 +32,7 @@ impl<'a> FromPyObject<'a> for PyTimeUnit {
 
 /// A Python-facing wrapper around [DataType].
 #[derive(PartialEq, Eq, Debug)]
-#[pyclass(module = "arro3.core._core", name = "DataType", subclass)]
+#[pyclass(module = "arro3.core._core", name = "DataType", subclass, frozen)]
 pub struct PyDataType(DataType);
 
 impl PyDataType {

--- a/pyo3-arrow/src/field.rs
+++ b/pyo3-arrow/src/field.rs
@@ -20,7 +20,7 @@ use crate::PyDataType;
 ///
 /// This is a wrapper around a [FieldRef].
 #[derive(Debug)]
-#[pyclass(module = "arro3.core._core", name = "Field", subclass)]
+#[pyclass(module = "arro3.core._core", name = "Field", subclass, frozen)]
 pub struct PyField(FieldRef);
 
 impl PyField {

--- a/pyo3-arrow/src/record_batch.rs
+++ b/pyo3-arrow/src/record_batch.rs
@@ -24,7 +24,7 @@ use crate::{PyArray, PyField, PySchema};
 /// A Python-facing Arrow record batch.
 ///
 /// This is a wrapper around a [RecordBatch].
-#[pyclass(module = "arro3.core._core", name = "RecordBatch", subclass)]
+#[pyclass(module = "arro3.core._core", name = "RecordBatch", subclass, frozen)]
 #[derive(Debug)]
 pub struct PyRecordBatch(RecordBatch);
 

--- a/pyo3-arrow/src/scalar.rs
+++ b/pyo3-arrow/src/scalar.rs
@@ -19,7 +19,7 @@ use crate::{PyArray, PyField};
 
 /// A Python-facing Arrow scalar
 #[derive(Debug)]
-#[pyclass(module = "arro3.core._core", name = "Scalar", subclass)]
+#[pyclass(module = "arro3.core._core", name = "Scalar", subclass, frozen)]
 pub struct PyScalar {
     array: ArrayRef,
     field: FieldRef,

--- a/pyo3-arrow/src/schema.rs
+++ b/pyo3-arrow/src/schema.rs
@@ -20,7 +20,7 @@ use crate::{PyDataType, PyField, PyTable};
 ///
 /// This is a wrapper around a [SchemaRef].
 #[derive(Debug)]
-#[pyclass(module = "arro3.core._core", name = "Schema", subclass)]
+#[pyclass(module = "arro3.core._core", name = "Schema", subclass, frozen)]
 pub struct PySchema(SchemaRef);
 
 impl PySchema {

--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -32,7 +32,7 @@ use crate::{PyChunkedArray, PyField, PyRecordBatch, PyRecordBatchReader, PySchem
 /// A Python-facing Arrow table.
 ///
 /// This is a wrapper around a [SchemaRef] and a `Vec` of [RecordBatch].
-#[pyclass(module = "arro3.core._core", name = "Table", subclass)]
+#[pyclass(module = "arro3.core._core", name = "Table", subclass, frozen)]
 #[derive(Debug)]
 pub struct PyTable {
     batches: Vec<RecordBatch>,


### PR DESCRIPTION
### Change list

- Add the [`frozen`](https://pyo3.rs/v0.23.3/class.html?highlight=frozen#frozen-classes-opting-out-of-interior-mutability) attribute to `#[pyclass]`. This should be a small performance improvement, and allows for accessing the interior of a class even without the GIL.

Ref https://github.com/developmentseed/obstore/pull/118