### PR TITLE
Fix build - update arrow to 54.2.1

### DIFF
--- a/pyo3-arrow/Cargo.toml
+++ b/pyo3-arrow/Cargo.toml
@@ -21,10 +21,10 @@ buffer_protocol = []
 [dependencies]
 chrono = "0.4.39"
 
-arrow-array = "54"
-arrow-buffer = "54"
-arrow-schema = "54"
-arrow = { version = "54", features = ["ffi", "chrono-tz"] }
+arrow-array = "54.2.1"
+arrow-buffer = "54.2.1"
+arrow-schema = "54.2.1"
+arrow = { version = "54.2.1", features = ["ffi", "chrono-tz"] }
 pyo3 = { version = "0.23.4", features = ["chrono", "chrono-tz", "indexmap"] }
 half = "2"
 indexmap = "2"
@@ -32,7 +32,7 @@ numpy = { version = "0.23", features = ["half"] }
 thiserror = "1"
 
 [dev-dependencies]
-arrow-select = "54"
+arrow-select = "54.2.1"
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
Arrow 54.2.0 is broken and a [hotfix 54.2.1 was issued](https://github.com/apache/arrow-rs/releases/tag/54.2.1).

Without bumping the arrow version, this package does not build by default. 

```
$ cargo new --lib tmp
$ cd tmp
$ cargo add pyo3-arrow
$ cargo build

-- snip --
error[E0034]: multiple applicable items in scope
92  |         DatePart::Quarter => |d| d.quarter() as i32,
    |                                    ^^^^^^^ multiple `quarter` found
    |
note: candidate #1 is defined in the trait `ChronoDateExt`
-- snip --
```