### PR TITLE
Bump arro3 to pyo3 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "arrow-schema",
  "bytes",
  "futures",
- "object_store",
+ "object_store 0.12.0",
  "parquet",
  "pyo3",
  "pyo3-arrow",
@@ -1195,6 +1195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
+checksum = "a7cfbf3f0feededcaa4d289fe3079b03659e85c5b5a177f4ba6fb01ab4fb3e39"
 dependencies = [
  "half",
  "libc",
@@ -1501,6 +1510,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
+ "pyo3-build-config",
  "rustc-hash",
 ]
 
@@ -1520,14 +1530,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
 dependencies = [
  "async-trait",
- "base64",
  "bytes",
  "chrono",
  "futures",
+ "humantime",
+ "itertools 0.13.0",
+ "parking_lot",
+ "percent-encoding",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "object_store"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ce831b09395f933addbc56d894d889e4b226eba304d4e7adbab591e26daf1e"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
  "httparse",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -1538,7 +1572,8 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "url",
@@ -1614,7 +1649,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store",
+ "object_store 0.11.2",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -1749,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1770,9 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-arrow"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e51f9bb00155f44cd5b1b87199d364613b0cbdf082982f5f0d754287d9b4686"
+version = "0.8.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1788,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+checksum = "dd0b83dc42f9d41f50d38180dad65f0c99763b65a3ff2a81bf351dd35a1df8bf"
 dependencies = [
  "futures",
  "once_cell",
@@ -1801,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1811,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1821,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-file"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3134dfe0d6458ea56d6c1cd4047c8894f331297aaf53eb9bf046ac7485dd469b"
+checksum = "b7fc1b57b1e7e2047d0907ded8086866ba8390a8b0ba512bcc35ececbffed72a"
 dependencies = [
  "pyo3",
  "skeptic",
@@ -1831,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1843,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1856,14 +1889,23 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.1.0-beta.1"
-source = "git+https://github.com/developmentseed/object-store-rs?rev=bad34862a92849dd7b69c28cd4c225446d3d15ab#bad34862a92849dd7b69c28cd4c225446d3d15ab"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d86e64cc8cb37a7950eadeee4a80c7d8467c3871baf176996af917fa6cda36"
 dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
  "futures",
- "object_store",
+ "humantime",
+ "itertools 0.14.0",
+ "object_store 0.12.0",
+ "percent-encoding",
  "pyo3",
  "pyo3-async-runtimes",
+ "serde",
  "thiserror 1.0.69",
+ "tokio",
  "url",
 ]
 
@@ -2422,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ arrow-select = "54"
 bytes = "1.7.0"
 half = "2"
 indexmap = "2"
-numpy = "0.23"
-object_store = "0.11"
+numpy = "0.24"
+object_store = "0.12"
 parquet = "54"
-pyo3 = { version = "0.23", features = ["macros", "indexmap"] }
-pyo3-arrow = "0.7"
-# pyo3-arrow = { path = "./pyo3-arrow" }
-pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
-pyo3-file = "0.10"
-pyo3-object_store = { git = "https://github.com/developmentseed/object-store-rs", rev = "bad34862a92849dd7b69c28cd4c225446d3d15ab" }
+pyo3 = { version = "0.24", features = ["macros", "indexmap"] }
+# pyo3-arrow = "0.8"
+pyo3-arrow = { path = "./pyo3-arrow" }
+pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }
+pyo3-file = "0.11"
+pyo3-object_store = "0.2"
 thiserror = "1.0.63"
 
 [profile.release]

--- a/arro3-io/src/lib.rs
+++ b/arro3-io/src/lib.rs
@@ -39,7 +39,7 @@ fn _io(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
 
     m.add_wrapped(wrap_pyfunction!(___version))?;
 
-    pyo3_object_store::register_store_module(py, m, "arro3.io")?;
+    pyo3_object_store::register_store_module(py, m, "arro3.io", "store")?;
 
     m.add_wrapped(wrap_pyfunction!(csv::infer_csv_schema))?;
     m.add_wrapped(wrap_pyfunction!(csv::read_csv))?;

--- a/tests/core/test_array.py
+++ b/tests/core/test_array.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pyarrow as pa
-import pytest
 from arro3.core import Array, DataType, Table
 
 
@@ -24,9 +23,6 @@ def test_constructor():
     # assert pa.array(arr) == pa.array([b"1", b"2", b"3"], pa.binary(1))
 
 
-@pytest.mark.skip(
-    "Arro3 currently uses published instead of relative path pyo3-arrow, and arro3 hasn't been bumped to pyo3 0.24 yet. This should be un-skipped before the next arro3 release"
-)
 def test_constructor_null():
     arr = Array([1, None, 3], DataType.int16())
     assert pa.array(arr) == pa.array([1, None, 3], pa.int16())


### PR DESCRIPTION
Now that pyo3-bytes and pyo3-object_store have released pyo3-0.24 compatible versions

Closes https://github.com/kylebarron/arro3/issues/301, ref https://github.com/kylebarron/arro3/issues/299