### PR TITLE
Minimize arrow crate dependency surface

### DIFF
--- a/pyo3-arrow/Cargo.lock
+++ b/pyo3-arrow/Cargo.lock
@@ -41,41 +41,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6422e12ac345a0678d7a17e316238e3a40547ae7f92052b77bd86d5e0239f3fc"
-dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cf34bb1f48c41d3475927bcc7be498665b8e80b379b88f62a840337f8b8248"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "num",
-]
-
-[[package]]
 name = "arrow-array"
 version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,22 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-csv"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c8f959f7a1389b1dbd883cdcd37c3ed12475329c111912f7f69dad8195d8c6"
-dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "arrow-data"
 version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,71 +101,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-ipc"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bb3f727f049884c7603f0364bc9315363f356b59e9f605ea76541847e06a1e"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "flatbuffers",
-]
-
-[[package]]
-name = "arrow-json"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35de94f165ed8830aede72c35f238763794f0d49c69d30c44d49c9834267ff8c"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "indexmap",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa06e5f267dc53efbacb933485c79b6fc1685d3ffbe870a16ce4e696fb429da"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
-]
-
-[[package]]
-name = "arrow-row"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f1144bb456a2f9d82677bd3abcea019217e572fc8f07de5a7bac4b2c56eb2c"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "half",
-]
-
-[[package]]
 name = "arrow-schema"
 version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "105f01ec0090259e9a33a9263ec18ff223ab91a0ea9fbc18042f7e38005142f6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -231,23 +121,6 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "54.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fff9cd745a7039b66c47ecaf5954460f9fa12eed628f65170117ea93e64ee0"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "memchr",
- "num",
- "regex",
- "regex-syntax",
 ]
 
 [[package]]
@@ -270,12 +143,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -378,41 +245,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "flatbuffers"
-version = "24.12.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version",
-]
 
 [[package]]
 name = "getrandom"
@@ -488,12 +324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
-name = "itoa"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,12 +332,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexical-core"
@@ -824,9 +648,10 @@ dependencies = [
 name = "pyo3-arrow"
 version = "0.8.0"
 dependencies = [
- "arrow",
  "arrow-array",
  "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
  "arrow-schema",
  "arrow-select",
  "chrono",
@@ -948,15 +773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,47 +780,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
-
-[[package]]
-name = "semver"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
-
-[[package]]
-name = "serde"
-version = "1.0.217"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.217"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.138"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
-]
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "shlex"

--- a/pyo3-arrow/Cargo.toml
+++ b/pyo3-arrow/Cargo.toml
@@ -21,10 +21,12 @@ buffer_protocol = []
 [dependencies]
 chrono = "0.4.39"
 
-arrow-array = "54"
+arrow-array = { version = "54", features = ["chrono-tz", "ffi"] }
 arrow-buffer = "54"
+arrow-cast = "54"
+arrow-data = "54"
 arrow-schema = "54"
-arrow = { version = "54", features = ["ffi", "chrono-tz"] }
+arrow-select = "54"
 pyo3 = { version = "0.24", features = ["chrono", "chrono-tz", "indexmap"] }
 half = "2"
 indexmap = "2"

--- a/pyo3-arrow/src/array.rs
+++ b/pyo3-arrow/src/array.rs
@@ -1,8 +1,7 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use arrow::compute::concat;
-use arrow::datatypes::{
+use arrow_array::types::{
     Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
     UInt64Type, UInt8Type,
 };
@@ -10,7 +9,10 @@ use arrow_array::{
     Array, ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Datum, LargeBinaryArray,
     LargeStringArray, PrimitiveArray, StringArray, StringViewArray,
 };
+use arrow_cast::cast;
 use arrow_schema::{ArrowError, DataType, Field, FieldRef};
+use arrow_select::concat::concat;
+use arrow_select::take::take;
 use numpy::PyUntypedArray;
 use pyo3::exceptions::{PyIndexError, PyNotImplementedError, PyValueError};
 use pyo3::prelude::*;
@@ -246,7 +248,7 @@ impl PyArray {
 
     #[cfg(feature = "buffer_protocol")]
     fn buffer(&self) -> crate::buffer::PyArrowBuffer {
-        use arrow::array::AsArray;
+        use arrow_array::cast::AsArray;
 
         match self.array.data_type() {
             DataType::Int64 => {
@@ -367,7 +369,7 @@ impl PyArray {
 
     fn cast(&self, target_type: PyField) -> PyArrowResult<Arro3Array> {
         let new_field = target_type.into_inner();
-        let new_array = arrow::compute::cast(self.as_ref(), new_field.data_type())?;
+        let new_array = cast(self.as_ref(), new_field.data_type())?;
         Ok(PyArray::new(new_array, new_field).into())
     }
 
@@ -395,7 +397,7 @@ impl PyArray {
     }
 
     fn take(&self, indices: PyArray) -> PyArrowResult<Arro3Array> {
-        let new_array = arrow::compute::take(self.as_ref(), indices.as_ref(), None)?;
+        let new_array = take(self.as_ref(), indices.as_ref(), None)?;
         Ok(PyArray::new(new_array, self.field.clone()).into())
     }
 

--- a/pyo3-arrow/src/buffer.rs
+++ b/pyo3-arrow/src/buffer.rs
@@ -6,7 +6,7 @@ use std::os::raw::c_int;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
-use arrow::array::BooleanBuilder;
+use arrow_array::builder::BooleanBuilder;
 use arrow_array::{
     ArrayRef, FixedSizeListArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
     Int8Array, UInt16Array, UInt32Array, UInt64Array, UInt8Array,

--- a/pyo3-arrow/src/chunked.rs
+++ b/pyo3-arrow/src/chunked.rs
@@ -1,9 +1,10 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use arrow::compute::concat;
 use arrow_array::{Array, ArrayRef};
+use arrow_cast::cast;
 use arrow_schema::{ArrowError, DataType, Field, FieldRef};
+use arrow_select::concat::concat;
 use pyo3::exceptions::{PyIndexError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyTuple, PyType};
@@ -382,7 +383,7 @@ impl PyChunkedArray {
         let new_chunks = self
             .chunks
             .iter()
-            .map(|chunk| arrow::compute::cast(&chunk, new_field.data_type()))
+            .map(|chunk| cast(&chunk, new_field.data_type()))
             .collect::<Result<Vec<_>, ArrowError>>()?;
         Ok(PyChunkedArray::try_new(new_chunks, new_field)?.into())
     }

--- a/pyo3-arrow/src/datatypes.rs
+++ b/pyo3-arrow/src/datatypes.rs
@@ -1,8 +1,7 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use arrow::datatypes::DataType;
-use arrow_schema::{Field, IntervalUnit, TimeUnit};
+use arrow_schema::{DataType, Field, IntervalUnit, TimeUnit};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::prelude::*;

--- a/pyo3-arrow/src/error.rs
+++ b/pyo3-arrow/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 pub enum PyArrowError {
     /// A wrapped [arrow::error::ArrowError]
     #[error(transparent)]
-    ArrowError(#[from] arrow::error::ArrowError),
+    ArrowError(#[from] arrow_schema::ArrowError),
 
     /// A wrapped [PyErr]
     #[error(transparent)]

--- a/pyo3-arrow/src/ffi/from_python/ffi_stream.rs
+++ b/pyo3-arrow/src/ffi/from_python/ffi_stream.rs
@@ -7,11 +7,10 @@
 use std::ffi::CStr;
 use std::sync::Arc;
 
-use arrow::datatypes::{Field, FieldRef};
-use arrow::error::ArrowError;
-use arrow::ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
-use arrow::ffi_stream::FFI_ArrowArrayStream;
+use arrow_array::ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
+use arrow_array::ffi_stream::FFI_ArrowArrayStream;
 use arrow_array::{make_array, Array};
+use arrow_schema::{ArrowError, Field, FieldRef};
 
 use crate::ffi::ArrayReader;
 

--- a/pyo3-arrow/src/ffi/from_python/utils.rs
+++ b/pyo3-arrow/src/ffi/from_python/utils.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
-use arrow::array::ArrayData;
-use arrow::datatypes::Field;
-use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
-use arrow::ffi_stream::FFI_ArrowArrayStream;
+use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow_array::ffi_stream::FFI_ArrowArrayStream;
 use arrow_array::{make_array, Array, ArrayRef, StructArray};
-use arrow_schema::DataType;
+use arrow_data::ArrayData;
+use arrow_schema::{DataType, Field};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyTuple};
@@ -131,7 +130,7 @@ pub(crate) fn import_array_pycapsules(
     let schema_ptr = unsafe { schema_capsule.reference::<FFI_ArrowSchema>() };
     let array = unsafe { FFI_ArrowArray::from_raw(array_capsule.pointer() as _) };
 
-    let array_data = unsafe { arrow::ffi::from_ffi(array, schema_ptr) }
+    let array_data = unsafe { arrow_array::ffi::from_ffi(array, schema_ptr) }
         .map_err(|err| PyTypeError::new_err(err.to_string()))?;
     let field = Field::try_from(schema_ptr).map_err(|err| PyTypeError::new_err(err.to_string()))?;
     let (array, data_len) = our_make_array(array_data);

--- a/pyo3-arrow/src/ffi/to_python/chunked.rs
+++ b/pyo3-arrow/src/ffi/to_python/chunked.rs
@@ -1,6 +1,5 @@
-use arrow::datatypes::FieldRef;
-use arrow::error::ArrowError;
 use arrow_array::ArrayRef;
+use arrow_schema::{ArrowError, FieldRef};
 
 /// Trait for types that can read `ArrayRef`'s.
 ///

--- a/pyo3-arrow/src/ffi/to_python/ffi_stream.rs
+++ b/pyo3-arrow/src/ffi/to_python/ffi_stream.rs
@@ -3,7 +3,6 @@
 //! This is derived from
 //! <https://github.com/apache/arrow-rs/blob/9d0abcc6f4e11594c23811c2c2d297f2eb2963af/arrow/src/ffi_stream.rs>
 
-use arrow::ffi_stream::FFI_ArrowArrayStream;
 use std::ptr::addr_of;
 use std::{
     convert::TryFrom,
@@ -11,9 +10,10 @@ use std::{
     os::raw::{c_char, c_int, c_void},
 };
 
-use arrow::array::Array;
-use arrow::error::ArrowError;
-use arrow::ffi::*;
+use arrow_array::ffi::*;
+use arrow_array::ffi_stream::FFI_ArrowArrayStream;
+use arrow_array::Array;
+use arrow_schema::ArrowError;
 
 use crate::ffi::to_python::chunked::ArrayReader;
 

--- a/pyo3-arrow/src/ffi/to_python/utils.rs
+++ b/pyo3-arrow/src/ffi/to_python/utils.rs
@@ -1,10 +1,9 @@
 use std::ffi::CString;
 use std::sync::Arc;
 
-use arrow::compute::can_cast_types;
-use arrow::compute::kernels::cast;
-use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_array::Array;
+use arrow_cast::{can_cast_types, cast};
 use arrow_schema::{ArrowError, Field, FieldRef};
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyTuple};

--- a/pyo3-arrow/src/interop/numpy/from_numpy.rs
+++ b/pyo3-arrow/src/interop/numpy/from_numpy.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow::datatypes::{
+use arrow_array::types::{
     Float16Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
     UInt32Type, UInt64Type, UInt8Type,
 };

--- a/pyo3-arrow/src/interop/numpy/to_numpy.rs
+++ b/pyo3-arrow/src/interop/numpy/to_numpy.rs
@@ -1,5 +1,5 @@
-use arrow::array::AsArray;
-use arrow::datatypes::*;
+use arrow_array::cast::AsArray;
+use arrow_array::types::*;
 use arrow_array::Array;
 use arrow_schema::DataType;
 use numpy::ToPyArray;

--- a/pyo3-arrow/src/record_batch.rs
+++ b/pyo3-arrow/src/record_batch.rs
@@ -1,10 +1,11 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use arrow::array::AsArray;
-use arrow::compute::{concat_batches, take_record_batch};
+use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, StructArray};
 use arrow_schema::{DataType, Field, Schema, SchemaBuilder};
+use arrow_select::concat::concat_batches;
+use arrow_select::take::take_record_batch;
 use indexmap::IndexMap;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;

--- a/pyo3-arrow/src/record_batch_reader.rs
+++ b/pyo3-arrow/src/record_batch_reader.rs
@@ -39,7 +39,7 @@ impl PyRecordBatchReader {
     /// Construct from a raw Arrow C Stream capsule
     pub fn from_arrow_pycapsule(capsule: &Bound<PyCapsule>) -> PyResult<Self> {
         let stream = import_stream_pycapsule(capsule)?;
-        let stream_reader = arrow::ffi_stream::ArrowArrayStreamReader::try_new(stream)
+        let stream_reader = arrow_array::ffi_stream::ArrowArrayStreamReader::try_new(stream)
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         Ok(Self::new(Box::new(stream_reader)))

--- a/pyo3-arrow/src/scalar.rs
+++ b/pyo3-arrow/src/scalar.rs
@@ -2,11 +2,12 @@ use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use arrow::array::AsArray;
-use arrow::datatypes::*;
+use arrow_array::cast::AsArray;
 use arrow_array::timezone::Tz;
+use arrow_array::types::*;
 use arrow_array::{Array, ArrayRef, Datum, UnionArray};
-use arrow_schema::{ArrowError, DataType, FieldRef};
+use arrow_cast::cast;
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, TimeUnit};
 use indexmap::IndexMap;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyList, PyTuple, PyType};
@@ -407,7 +408,7 @@ impl PyScalar {
 
     fn cast(&self, target_type: PyField) -> PyArrowResult<Arro3Scalar> {
         let new_field = target_type.into_inner();
-        let new_array = arrow::compute::cast(&self.array, new_field.data_type())?;
+        let new_array = cast(&self.array, new_field.data_type())?;
         Ok(PyScalar::try_new(new_array, new_field).unwrap().into())
     }
 

--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -1,11 +1,11 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use arrow::compute::concat_batches;
-use arrow::ffi_stream::ArrowArrayStreamReader as ArrowRecordBatchStreamReader;
+use arrow_array::ffi_stream::ArrowArrayStreamReader as ArrowRecordBatchStreamReader;
 use arrow_array::{ArrayRef, RecordBatchReader, StructArray};
 use arrow_array::{RecordBatch, RecordBatchIterator};
 use arrow_schema::{ArrowError, Field, Schema, SchemaRef};
+use arrow_select::concat::concat_batches;
 use indexmap::IndexMap;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;


### PR DESCRIPTION
Don't depend on `arrow`; instead depend on individual arrow crates for a smaller dependency tree and faster compile times.