### PR TITLE
feat: access value_fields and inner fields

### DIFF
--- a/arro3-core/python/arro3/core/_data_type.pyi
+++ b/arro3-core/python/arro3/core/_data_type.pyi
@@ -1,5 +1,6 @@
 from typing import Literal, Sequence
 
+from ._field import Field
 from .types import ArrowSchemaExportable
 
 class DataType:
@@ -73,6 +74,15 @@ class DataType:
     @property
     def value_type(self) -> DataType | None:
         """The child type, if it exists."""
+
+    @property
+    def value_field(self) -> Field | None:
+        """The child field, if it exists. Only applicable to list types."""
+
+    @property
+    def fields(self) -> Sequence[Field]:
+        """The inner fields, if they exists. Only applicable to Struct type."""
+
     #################
     #### Constructors
     #################

--- a/pyo3-arrow/src/datatypes.rs
+++ b/pyo3-arrow/src/datatypes.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyTuple, PyType};
 
 use crate::error::PyArrowResult;
-use crate::export::Arro3DataType;
+use crate::export::{Arro3DataType, Arro3Field};
 use crate::ffi::from_python::utils::import_schema_pycapsule;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_schema;
 use crate::ffi::to_schema_pycapsule;
@@ -260,6 +260,33 @@ impl PyDataType {
             DataType::Dictionary(_key_type, value_type) => {
                 Some(PyDataType::new(*value_type.clone()).into())
             }
+            _ => None,
+        }
+    }
+
+    #[getter]
+    fn value_field(&self) -> Option<Arro3Field> {
+        match &self.0 {
+            DataType::FixedSizeList(value_field, _)
+            | DataType::List(value_field)
+            | DataType::LargeList(value_field)
+            | DataType::ListView(value_field)
+            | DataType::LargeListView(value_field) => {
+                Some(PyField::new(value_field.clone()).into())
+            }
+            _ => None,
+        }
+    }
+
+    #[getter]
+    fn fields(&self) -> Option<Vec<Arro3Field>> {
+        match &self.0 {
+            DataType::Struct(fields) => Some(
+                fields
+                    .into_iter()
+                    .map(|f| PyField::new(f.clone()).into())
+                    .collect::<Vec<_>>(),
+            ),
             _ => None,
         }
     }

--- a/tests/core/test_data_type.py
+++ b/tests/core/test_data_type.py
@@ -8,6 +8,23 @@ def test_value_type_fixed_size_list_type():
     assert list_dt.value_type == value_type
 
 
+def test_value_field_list_type():
+    value_type = DataType.int8()
+    value_field = Field("inner", value_type, nullable=True)
+    list_dt = DataType.list(
+        value_field,
+        2,
+    )
+    assert list_dt.value_field == value_field
+
+
+def test_fields_struct_type():
+    field_foo = Field("foo", DataType.int8(), nullable=True)
+    field_bar = Field("bar", DataType.string(), nullable=False)
+    struct_type = DataType.struct([field_foo, field_bar])
+    assert struct_type.fields == [field_foo, field_bar]
+
+
 @pytest.mark.xfail
 def test_list_data_type_construction_with_dt():
     _ = DataType.list(DataType.int16())


### PR DESCRIPTION
For proper schema traversal in `deltalake` I need to be able to access the value_field of a list type and the inner_fields of a struct. 