### PR TITLE
fix(arro3-core): Add typing-extensions as a dependency for arro3-core

### DIFF
--- a/arro3-core/pyproject.toml
+++ b/arro3-core/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "arro3-core"
 requires-python = ">=3.9"
-dependencies = []
+dependencies = ["typing-extensions; python_version < '3.12'"]
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Closes https://github.com/kylebarron/arro3/issues/346