### PR TITLE
feat(release): Enable sdist artifacts

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,26 +183,26 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}-${{ matrix.module }}
           path: dist
 
-  # sdist:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       module:
-  #         - arro3-core
-  #         - arro3-compute
-  #         - arro3-io
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Build sdist
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         command: sdist
-  #         args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
-  #     - name: Upload sdist
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-sdist-${{ matrix.module }}
-  #         path: dist
+  sdist:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module:
+          - arro3-core
+          - arro3-compute
+          - arro3-io
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist --manifest-path ${{ matrix.module }}/Cargo.toml
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist-${{ matrix.module }}
+          path: dist
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
While testing various packages on free-threaded Python (3.13t and 3.14t), I needed to install arro3. Because there are no prebuilt wheels or a published sdist, I currently have to install arro3 directly from Git. To make this easier, I’d like to re-enable publishing of the sdist distribution.

I noticed this was previously disabled in [#113](https://github.com/kylebarron/arro3/pull/113). I tested the sdist locally and did not encounter any issues. If there were specific problems that led to disabling it, could you elaborate on them and confirm whether they’re now resolved?