### PR TITLE
feat(arro3-core): Maintain timezone info when converting scalar tz to `datetime.datetime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,11 +466,12 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.4"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
- "unicode-segmentation",
+ "strum",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -1700,6 +1701,8 @@ dependencies = [
  "arrow-data 56.0.0",
  "arrow-schema",
  "arrow-select",
+ "chrono",
+ "chrono-tz",
  "half",
  "indexmap",
  "numpy",
@@ -2297,6 +2300,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,12 +2616,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/pyo3-arrow/Cargo.toml
+++ b/pyo3-arrow/Cargo.toml
@@ -25,6 +25,8 @@ arrow-cast = { version = "56", features = ["prettyprint"] }
 arrow-data = "56"
 arrow-schema = "56"
 arrow-select = "56"
+chrono = "0.4"
+chrono-tz = "0.10"
 pyo3 = { version = "0.26", features = ["chrono", "chrono-tz", "indexmap"] }
 half = "2"
 indexmap = "2"

--- a/pyo3-arrow/src/scalar/temporal.rs
+++ b/pyo3-arrow/src/scalar/temporal.rs
@@ -1,0 +1,158 @@
+use std::str::FromStr;
+
+use arrow_array::temporal_conversions::as_datetime;
+use arrow_array::ArrowPrimitiveType;
+use arrow_schema::ArrowError;
+use chrono::offset::TimeZone;
+use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{LocalResult, NaiveDate, NaiveDateTime, Offset};
+use pyo3::prelude::*;
+
+/// An [`Offset`] for [`Tz`]
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct PyArrowTzOffset {
+    tz: PyArrowTz,
+    offset: FixedOffset,
+}
+
+impl std::fmt::Display for PyArrowTzOffset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.offset.fmt(f)
+    }
+}
+
+impl Offset for PyArrowTzOffset {
+    fn fix(&self) -> FixedOffset {
+        self.offset
+    }
+}
+/// An Arrow [`TimeZone`]
+///
+/// This is vendored from upstream so we can implement `IntoPyObject`, while also needing to
+/// implement chrono::TimeZone
+///
+/// https://github.com/apache/arrow-rs/blob/77df2ee42d8ca1d1557a64681b240b8409deef01/arrow-array/src/timezone.rs#L78-L80
+#[derive(Debug, Clone, Copy, IntoPyObject)]
+pub(crate) struct PyArrowTz(TzInner);
+
+#[derive(Debug, Copy, Clone, IntoPyObject)]
+pub(crate) enum TzInner {
+    Timezone(chrono_tz::Tz),
+    Offset(FixedOffset),
+}
+
+macro_rules! tz {
+    ($s:ident, $tz:ident, $b:block) => {
+        match $s.0 {
+            TzInner::Timezone($tz) => $b,
+            TzInner::Offset($tz) => $b,
+        }
+    };
+}
+
+impl TimeZone for PyArrowTz {
+    type Offset = PyArrowTzOffset;
+
+    fn from_offset(offset: &Self::Offset) -> Self {
+        offset.tz
+    }
+
+    fn offset_from_local_date(&self, local: &NaiveDate) -> LocalResult<Self::Offset> {
+        tz!(self, tz, {
+            tz.offset_from_local_date(local).map(|x| PyArrowTzOffset {
+                tz: *self,
+                offset: x.fix(),
+            })
+        })
+    }
+
+    fn offset_from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<Self::Offset> {
+        tz!(self, tz, {
+            tz.offset_from_local_datetime(local)
+                .map(|x| PyArrowTzOffset {
+                    tz: *self,
+                    offset: x.fix(),
+                })
+        })
+    }
+
+    fn offset_from_utc_date(&self, utc: &NaiveDate) -> Self::Offset {
+        tz!(self, tz, {
+            PyArrowTzOffset {
+                tz: *self,
+                offset: tz.offset_from_utc_date(utc).fix(),
+            }
+        })
+    }
+
+    fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> Self::Offset {
+        tz!(self, tz, {
+            PyArrowTzOffset {
+                tz: *self,
+                offset: tz.offset_from_utc_datetime(utc).fix(),
+            }
+        })
+    }
+}
+
+impl FromStr for PyArrowTz {
+    type Err = ArrowError;
+
+    fn from_str(tz: &str) -> Result<Self, Self::Err> {
+        match parse_fixed_offset(tz) {
+            Some(offset) => Ok(Self(TzInner::Offset(offset))),
+            None => Ok(Self(TzInner::Timezone(tz.parse().map_err(|e| {
+                ArrowError::ParseError(format!("Invalid timezone \"{tz}\": {e}"))
+            })?))),
+        }
+    }
+}
+
+/// Parses a fixed offset of the form "+09:00", "-09" or "+0930"
+///
+/// Vendored from upstream
+/// https://github.com/apache/arrow-rs/blob/77df2ee42d8ca1d1557a64681b240b8409deef01/arrow-array/src/timezone.rs#L24-L49
+///
+/// Upstream doesn't want to expose the TzInner enum, only expose as string
+/// https://github.com/apache/arrow-rs/issues/7173#issuecomment-2675276458
+///
+/// While we need to discern between fixed offset and tz string so that we can convert to correct
+/// Python tz class
+fn parse_fixed_offset(tz: &str) -> Option<FixedOffset> {
+    let bytes = tz.as_bytes();
+
+    let mut values = match bytes.len() {
+        // [+-]XX:XX
+        6 if bytes[3] == b':' => [bytes[1], bytes[2], bytes[4], bytes[5]],
+        // [+-]XXXX
+        5 => [bytes[1], bytes[2], bytes[3], bytes[4]],
+        // [+-]XX
+        3 => [bytes[1], bytes[2], b'0', b'0'],
+        _ => return None,
+    };
+    values.iter_mut().for_each(|x| *x = x.wrapping_sub(b'0'));
+    if values.iter().any(|x| *x > 9) {
+        return None;
+    }
+    let secs =
+        (values[0] * 10 + values[1]) as i32 * 60 * 60 + (values[2] * 10 + values[3]) as i32 * 60;
+
+    match bytes[0] {
+        b'+' => FixedOffset::east_opt(secs),
+        b'-' => FixedOffset::west_opt(secs),
+        _ => None,
+    }
+}
+
+/// Converts an [`ArrowPrimitiveType`] to [`DateTime<Tz>`]
+///
+/// Vendored from
+/// https://github.com/apache/arrow-rs/blob/77df2ee42d8ca1d1557a64681b240b8409deef01/arrow-array/src/temporal_conversions.rs#L274-L278
+/// So we can use our own PyArrowTz type
+pub(crate) fn as_datetime_with_timezone<T: ArrowPrimitiveType>(
+    v: i64,
+    tz: PyArrowTz,
+) -> Option<DateTime<PyArrowTz>> {
+    let naive = as_datetime::<T>(v)?;
+    Some(Utc.from_utc_datetime(&naive).with_timezone(&tz))
+}


### PR DESCRIPTION
Closes https://github.com/kylebarron/arro3/issues/397