### PR TITLE
ci: Build 3.14t wheels

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.4.x"
+          version: "0.9.x"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,79 +1,79 @@
 name: Python
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+    push:
+        branches:
+            - main
+    pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  pre-commit:
-    name: Run pre-commit on Python code
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    pre-commit:
+        name: Run pre-commit on Python code
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
 
-      - name: Cache pre-commit virtualenvs
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-3|${{ hashFiles('.pre-commit-config.yaml') }}
+            - name: Cache pre-commit virtualenvs
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/pre-commit
+                  key: pre-commit-3|${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - name: run pre-commit
-        run: |
-          python -m pip install pre-commit
-          pre-commit run --all-files
+            - name: run pre-commit
+              run: |
+                  python -m pip install pre-commit
+                  pre-commit run --all-files
 
-  test-python:
-    name: Build and test Python
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: ["3.9", "3.12", "3.13", "3.13t"]
-    steps:
-      - uses: actions/checkout@v4
+    test-python:
+        name: Build and test Python
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: true
+            matrix:
+                python-version: ["3.9", "3.12", "3.13", "3.13t"]
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+            - uses: Swatinem/rust-cache@v2
 
-      - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          version: "0.8.x"
+            - name: Install a specific version of uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  enable-cache: true
+                  version: "0.8.x"
 
-      - name: Set up Python with uv
-        run: |
-          uv python install ${{ matrix.python-version }}
+            - name: Set up Python with uv
+              run: |
+                  uv python install ${{ matrix.python-version }}
 
-      - name: Build rust submodules
-        run: |
-          # Note: core module must be first, because it's depended on by others
-          uv run --python ${{ matrix.python-version }} maturin dev -m arro3-core/Cargo.toml
-          uv run --python ${{ matrix.python-version }} maturin dev -m arro3-compute/Cargo.toml
-          uv run --python ${{ matrix.python-version }} maturin dev -m arro3-io/Cargo.toml
+            - name: Build rust submodules
+              run: |
+                  # Note: core module must be first, because it's depended on by others
+                  uv run --python ${{ matrix.python-version }} maturin dev -m arro3-core/Cargo.toml
+                  uv run --python ${{ matrix.python-version }} maturin dev -m arro3-compute/Cargo.toml
+                  uv run --python ${{ matrix.python-version }} maturin dev -m arro3-io/Cargo.toml
 
-      - name: Run python tests
-        if: matrix.python-version != '3.13t'
-        run: |
-          uv run --python ${{ matrix.python-version }} pytest tests
+            - name: Run python tests
+              if: matrix.python-version != '3.13t'
+              run: |
+                  uv run --python ${{ matrix.python-version }} pytest tests
 
-      - name: Run python tests with --require-gil-disabled
-        if: matrix.python-version == '3.13t'
-        run: |
-          uv run --python ${{ matrix.python-version }} pytest tests --require-gil-disabled
+            - name: Run python tests with --require-gil-disabled
+              if: matrix.python-version == '3.13t'
+              run: |
+                  uv run --python ${{ matrix.python-version }} pytest tests --require-gil-disabled
 
-      # Ensure docs build without warnings
-      - name: Check docs
-        run: uv run --group docs mkdocs build --strict
+            # Ensure docs build without warnings
+            - name: Check docs
+              run: uv run --group docs mkdocs build --strict

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,10 +50,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.4.x"
+          version: "0.9.x"
 
       - name: Install Python versions
         run: uv python install 3.9 3.10 3.11 3.13t 3.14t pypy3.11
@@ -103,10 +103,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.4.x"
+          version: "0.9.x"
 
       - name: Install Python versions
         run: uv python install 3.9 3.10 3.11 3.13t 3.14t pypy3.11
@@ -197,10 +197,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.4.x"
+          version: "0.9.x"
 
       - name: Install Python versions
         run: uv python install 3.9 3.10 3.11 3.13t 3.14t pypy3.11


### PR DESCRIPTION
### Change list

- Add Python 3.14t wheels
- Change pypy3.10 wheels to pypy3.11 wheels (pyo3 0.27 no longer supports pypy3.10)