### PR TITLE
fix: off by one when checking if an index is valid

### DIFF
--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -561,7 +561,7 @@ impl PyTable {
     }
 
     fn remove_column(&self, i: usize) -> PyArrowResult<Arro3Table> {
-        if i > self.num_columns() {
+        if i >= self.num_columns() {
             return Err(PyIndexError::new_err(format!("Invalid column index \"{i}\"")).into());
         }
 

--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -364,7 +364,7 @@ def test_remove_column():
     assert len(table.columns) == 1
 
     with pytest.raises(IndexError, match="Invalid column index"):
-        table.remove_column(10)
+        table.remove_column(1)
 
     # Other types than int raise an Error
     with pytest.raises(TypeError):


### PR DESCRIPTION
Sorry the logic in #442 is off by one. I looked at it again and something _felt_ off.

If a table has **2** columns, the valid indexes are [*0*, *1*], `remove_column(2)` would not trigger `i > num_columns`, and index *2* is not valid, we are off by one. :=D