### PR TITLE
fix: Rename `names` to `columns` parameter in `Tables.drop_columns`

### DIFF
--- a/arro3-core/python/arro3/core/_table.pyi
+++ b/arro3-core/python/arro3/core/_table.pyi
@@ -317,13 +317,13 @@ class Table:
             The rechunked table.
         """
 
-    def drop_columns(self, names: Sequence[str]) -> Table:
+    def drop_columns(self, columns: Sequence[str]) -> Table:
         """Create a new Table with the `columns` removed.
 
          An empty input does not remove any column.
 
         Args:
-            names: The name of the columns to drop, case-sensitive.
+            columns: The name of the columns to drop, case-sensitive.
 
         Returns:
             A new table without the specified columns.

--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -399,21 +399,21 @@ impl PyTable {
         Ok(Self::try_new(batches, schema)?)
     }
 
-    fn drop_columns(&self, names: Vec<String>) -> PyArrowResult<Arro3Table> {
-        let current_names = self.column_names();
-        let mut pos: HashMap<&str, usize> = HashMap::with_capacity(current_names.len());
-        for (i, s) in current_names.iter().enumerate() {
+    fn drop_columns(&self, columns: Vec<String>) -> PyArrowResult<Arro3Table> {
+        let current_columns = self.column_names();
+        let mut pos: HashMap<&str, usize> = HashMap::with_capacity(current_columns.len());
+        for (i, s) in current_columns.iter().enumerate() {
             pos.insert(s.as_str(), i);
         }
 
-        let drop_indices: Vec<usize> = names
+        let drop_indices: Vec<usize> = columns
             .iter()
             .filter_map(|s| pos.get(s.as_str()).copied())
             .collect();
 
-        if drop_indices.len() < names.len() {
+        if drop_indices.len() < columns.len() {
             // We have columns that don't exist
-            let missing: Vec<&str> = names
+            let missing: Vec<&str> = columns
                 .iter()
                 .map(|s| s.as_str())
                 .filter(|s| !pos.contains_key(s))

--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -422,6 +422,10 @@ def test_drop_columns():
     with pytest.raises(KeyError, match="not found"):
         table.drop_columns(["ccccde", "ccccde"])
 
+    # keyword argument works as intended.
+    table = table.drop_columns(columns=["d", "e"])
+    assert not table.column_names
+
 
 class CustomException(Exception):
     pass


### PR DESCRIPTION
Fixes #452