### PR TITLE
fix: Properly return `IndexError` on incorrect index in `Table.add_column`

### DIFF
--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -442,6 +442,14 @@ impl PyTable {
             .into());
         }
 
+        if i > self.num_columns() {
+            return Err(PyIndexError::new_err(format!(
+                "Column index out of range, index is {i} but should be <= {}",
+                self.num_columns()
+            ))
+            .into());
+        }
+
         let column = column.rechunk(self.chunk_lengths())?;
 
         let mut fields = self.schema.fields().to_vec();

--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -181,6 +181,11 @@ def test_table_add_column():
     table = table.add_column(col_id + 1, c_name + "extra", Array(pa.array(c_value)))
     assert table.column(col_id).to_pylist() == c_value
 
+    with pytest.raises(
+        IndexError, match="Column index out of range, index is 6 but should be <= 5"
+    ):
+        table.add_column(table.num_columns + 1, "_", Array(pa.array(c_value)))
+
 
 def test_table_add_column_chunked():
     """Test that a table is correctly added in a chunked table."""


### PR DESCRIPTION
Fixes #454 