### PR TITLE
fix: `Table.rename` not modifying internals batches schema

### DIFF
--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -616,9 +616,13 @@ impl PyTable {
 
     fn rename_columns(&self, names: Vec<String>) -> PyArrowResult<Arro3Table> {
         if names.len() != self.num_columns() {
-            return Err(PyValueError::new_err("When names is a list[str], must pass the same number of names as there are columns.").into());
+            return Err(PyValueError::new_err(format!(
+                "Expected {} names, got {}",
+                self.num_columns(),
+                names.len()
+            ))
+            .into());
         }
-
         let new_fields = self
             .schema
             .fields()
@@ -630,7 +634,16 @@ impl PyTable {
             new_fields,
             self.schema.metadata().clone(),
         ));
-        Ok(PyTable::try_new(self.batches.clone(), new_schema)?.into())
+
+        let new_batches = self
+            .batches
+            .iter()
+            .map(|batch| {
+                RecordBatch::try_new(new_schema.clone(), batch.columns().to_vec()).unwrap()
+            })
+            .collect();
+
+        Ok(PyTable::try_new(new_batches, new_schema)?.into())
     }
 
     #[getter]

--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -302,6 +302,24 @@ def test_table_set_column_chunked():
     assert table.chunk_lengths == [2]
 
 
+def test_table_rename():
+    table = Table.from_arrays(
+        [pa.array(["a", "b"]), pa.array([1, 2]), pa.array(["x", "y"])],
+        names=["c0", "c1", "c2"],
+    )
+
+    new_names = ["d1", "d2", "d3"]
+    table = table.rename_columns(new_names)
+    assert table.column_names == new_names
+
+    with pytest.raises(ValueError, match="Expected 3 names, got 1"):
+        table.rename_columns(
+            [
+                "onlyoneargument",
+            ]
+        )
+
+
 def test_table_from_batches_empty_columns_with_len():
     df = pd.DataFrame({"a": [1, 2, 3]})
     no_columns = df[[]]


### PR DESCRIPTION
Fix: #445 and fixes #446 

Also changed the error to something more pythonic, e.g. `ValueError: Expected 4 names, got 1`