### PR TITLE
refactor: Use `Self` in `py.get_type` for clarity

### DIFF
--- a/pyo3-arrow/src/record_batch.rs
+++ b/pyo3-arrow/src/record_batch.rs
@@ -166,10 +166,10 @@ impl PyRecordBatch {
         if data.hasattr(intern!(py, "__arrow_c_array__"))? {
             Ok(data.extract::<PyRecordBatch>()?)
         } else if let Ok(mapping) = data.extract::<IndexMap<String, PyArray>>() {
-            Self::from_pydict(&py.get_type::<PyRecordBatch>(), mapping, metadata)
+            Self::from_pydict(&py.get_type::<Self>(), mapping, metadata)
         } else if let Ok(arrays) = data.extract::<Vec<PyArray>>() {
             Self::from_arrays(
-                &py.get_type::<PyRecordBatch>(),
+                &py.get_type::<Self>(),
                 arrays,
                 schema.ok_or(PyValueError::new_err(
                     "Schema must be passed with list of arrays",

--- a/pyo3-arrow/src/table.rs
+++ b/pyo3-arrow/src/table.rs
@@ -244,9 +244,9 @@ impl PyTable {
         {
             Ok(data.extract::<AnyRecordBatch>()?.into_table()?)
         } else if let Ok(mapping) = data.extract::<IndexMap<String, AnyArray>>() {
-            Self::from_pydict(&py.get_type::<PyTable>(), mapping, schema, metadata)
+            Self::from_pydict(&py.get_type::<Self>(), mapping, schema, metadata)
         } else if let Ok(arrays) = data.extract::<Vec<AnyArray>>() {
-            Self::from_arrays(&py.get_type::<PyTable>(), arrays, names, schema, metadata)
+            Self::from_arrays(&py.get_type::<Self>(), arrays, names, schema, metadata)
         } else {
             Err(PyTypeError::new_err(
                 "Expected Table-like input or dict of arrays or sequence of arrays.",


### PR DESCRIPTION
I think this is slightly clearer than using the literal name of the class