### PR TITLE
fix: Preserve schema metadata in RecordBatch PyCapsule export

### DIFF
--- a/pyo3-arrow/src/record_batch.rs
+++ b/pyo3-arrow/src/record_batch.rs
@@ -115,7 +115,8 @@ impl PyRecordBatch {
         record_batch: RecordBatch,
         requested_schema: Option<Bound<'py, PyCapsule>>,
     ) -> PyArrowResult<Bound<'py, PyTuple>> {
-        let field = Field::new_struct("", record_batch.schema_ref().fields().clone(), false);
+        let field = Field::new_struct("", record_batch.schema_ref().fields().clone(), false)
+            .with_metadata(record_batch.schema_ref().metadata().clone());
         let array: ArrayRef = Arc::new(StructArray::from(record_batch.clone()));
         to_array_pycapsules(py, field.into(), &array, requested_schema)
     }

--- a/tests/core/test_record_batch.py
+++ b/tests/core/test_record_batch.py
@@ -62,6 +62,16 @@ def test_batch_from_arrays():
         pa.RecordBatch.from_arrays([a, b], schema=pa.schema(schema), metadata=metadata)
 
 
+def test_schema_metadata_preserved_through_pycapsule():
+    """https://github.com/kylebarron/arro3/issues/473"""
+    a = pa.array([1, 2, 3])
+    metadata = {b"my_key": b"my_value"}
+    arro3_batch = RecordBatch.from_arrays([a], names=["x"], metadata=metadata)
+    assert arro3_batch.schema.metadata == metadata
+    roundtripped = pa.record_batch(arro3_batch)
+    assert roundtripped.schema.metadata == metadata
+
+
 class CustomException(Exception):
     pass
 


### PR DESCRIPTION
## Summary

- Fix `to_array_pycapsules` dropping schema-level metadata by chaining `.with_metadata()` onto the `Field::new_struct()` call, matching the pattern already used in `to_struct_array()`
- Add regression test that round-trips a `RecordBatch` with metadata through pyarrow via PyCapsule export

Closes #473

## Test plan

- [x] New test fails on `main` (metadata is `None` after round-trip)
- [x] New test passes with the fix
- [x] All existing `test_record_batch.py` tests pass
- [x] `cargo clippy -p pyo3-arrow` clean