### PR TITLE
feat: Add `arro3` Cargo feature to `pyo3-arrow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,6 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
  "arrow-schema",
  "arrow-select",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ numpy = "0.28"
 object_store = "0.12"
 parquet = ">=57,<57.2"
 pyo3 = { version = "0.28", features = ["macros", "indexmap"] }
-pyo3-arrow = { path = "pyo3-arrow" }
+pyo3-arrow = { path = "pyo3-arrow", features = ["arro3"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 pyo3-file = { git = "https://github.com/kylebarron/pyo3-file", rev = "f724ceaa7e06e7d227bf40b1d60adbb842963a44" }
 pyo3-object_store = "0.10"

--- a/pyo3-arrow/Cargo.lock
+++ b/pyo3-arrow/Cargo.lock
@@ -575,7 +575,6 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
  "arrow-schema",
  "arrow-select",
  "chrono",

--- a/pyo3-arrow/Cargo.toml
+++ b/pyo3-arrow/Cargo.toml
@@ -14,23 +14,26 @@ rust-version = "1.75"
 [features]
 default = ["buffer_protocol"]
 
+# Enable #[pyclass] and #[pymethods] definitions for arro3 Python classes.
+# External consumers that only need FFI/conversion should leave this off.
+arro3 = ["dep:indexmap", "pyo3/indexmap", "dep:chrono", "dep:chrono-tz", "arrow-array/chrono-tz", "pyo3/chrono", "pyo3/chrono-tz", "dep:half", "numpy/half"]
+
 # Support buffer protocol. Requires `abi3-py311` pyo3 feature or non-abi3
 # wheels.
 buffer_protocol = []
 
 [dependencies]
-arrow-array = { version = "57", features = ["chrono-tz", "ffi"] }
+arrow-array = { version = "57", features = ["ffi"] }
 arrow-buffer = "57"
 arrow-cast = { version = "57", features = ["prettyprint"] }
-arrow-data = "57"
 arrow-schema = "57"
 arrow-select = "57"
-chrono = "0.4"
-chrono-tz = "0.10"
-pyo3 = { version = "0.28", features = ["chrono", "chrono-tz", "indexmap"] }
-half = "2"
-indexmap = "2"
-numpy = { version = "0.28", features = ["half"] }
+chrono = { version = "0.4", optional = true }
+chrono-tz = { version = "0.10", optional = true }
+pyo3 = { version = "0.28" }
+half = { version = "2", optional = true }
+indexmap = { version = "2", optional = true }
+numpy = { version = "0.28" }
 thiserror = "1"
 
 [lib]

--- a/pyo3-arrow/src/buffer.rs
+++ b/pyo3-arrow/src/buffer.rs
@@ -2,7 +2,6 @@
 
 use std::ffi::CStr;
 use std::os::raw;
-use std::os::raw::c_int;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
@@ -15,9 +14,10 @@ use arrow_buffer::{Buffer, ScalarBuffer};
 use arrow_schema::Field;
 use pyo3::buffer::{ElementType, PyBuffer};
 use pyo3::exceptions::PyValueError;
-use pyo3::ffi;
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+
+#[cfg(feature = "arro3")]
+use {pyo3::ffi, pyo3::types::PyBytes, std::os::raw::c_int};
 
 use crate::error::{PyArrowError, PyArrowResult};
 use crate::PyArray;
@@ -68,6 +68,7 @@ impl PyArrowBuffer {
     }
 }
 
+#[cfg(feature = "arro3")]
 #[pymethods]
 impl PyArrowBuffer {
     /// new

--- a/pyo3-arrow/src/field.rs
+++ b/pyo3-arrow/src/field.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -6,15 +5,21 @@ use arrow_schema::{Field, FieldRef};
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyCapsule, PyDict, PyTuple, PyType};
+use pyo3::types::{PyCapsule, PyTuple};
 
-use crate::error::PyArrowResult;
-use crate::export::{Arro3DataType, Arro3Field};
 use crate::ffi::from_python::utils::import_schema_pycapsule;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_schema;
 use crate::ffi::to_python::to_schema_pycapsule;
-use crate::input::MetadataInput;
-use crate::PyDataType;
+
+#[cfg(feature = "arro3")]
+use {
+    crate::error::PyArrowResult,
+    crate::export::{Arro3DataType, Arro3Field},
+    crate::input::MetadataInput,
+    crate::PyDataType,
+    pyo3::types::{PyBytes, PyDict, PyType},
+    std::collections::HashMap,
+};
 
 /// A Python-facing Arrow field.
 ///
@@ -45,9 +50,10 @@ impl PyField {
     /// Export this to a Python `arro3.core.Field`.
     pub fn to_arro3<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        let capsule = to_schema_pycapsule(py, self.0.as_ref())?;
         arro3_mod.getattr(intern!(py, "Field"))?.call_method1(
             intern!(py, "from_arrow_pycapsule"),
-            PyTuple::new(py, vec![self.__arrow_c_schema__(py)?])?,
+            PyTuple::new(py, vec![capsule])?,
         )
     }
 
@@ -63,7 +69,8 @@ impl PyField {
 
     /// Export this to a Python `nanoarrow.Schema`.
     pub fn to_nanoarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        to_nanoarrow_schema(py, &self.__arrow_c_schema__(py)?)
+        let capsule = to_schema_pycapsule(py, self.0.as_ref())?;
+        to_nanoarrow_schema(py, &capsule)
     }
 
     /// Export to a pyarrow.Field
@@ -110,6 +117,7 @@ impl Display for PyField {
     }
 }
 
+#[cfg(feature = "arro3")]
 #[pymethods]
 impl PyField {
     #[new]

--- a/pyo3-arrow/src/input.rs
+++ b/pyo3-arrow/src/input.rs
@@ -3,21 +3,26 @@
 //! These types tend to be used for unknown user input, and thus do not exist for return types,
 //! where the exact type is known.
 
-use std::collections::HashMap;
-use std::string::FromUtf8Error;
-use std::sync::Arc;
-
 use arrow_array::{Datum, RecordBatchIterator, RecordBatchReader};
-use arrow_schema::{ArrowError, Field, FieldRef, Fields, Schema, SchemaRef};
-use pyo3::exceptions::{PyIndexError, PyKeyError, PyValueError};
+use arrow_schema::{ArrowError, FieldRef, SchemaRef};
 use pyo3::prelude::*;
+
+#[cfg(feature = "arro3")]
+use {
+    arrow_schema::{Field, Fields, Schema},
+    pyo3::exceptions::{PyIndexError, PyKeyError, PyValueError},
+    std::collections::HashMap,
+    std::string::FromUtf8Error,
+    std::sync::Arc,
+};
 
 use crate::array_reader::PyArrayReader;
 use crate::error::PyArrowResult;
 use crate::ffi::{ArrayIterator, ArrayReader};
-use crate::{
-    PyArray, PyChunkedArray, PyField, PyRecordBatch, PyRecordBatchReader, PyScalar, PyTable,
-};
+use crate::{PyArray, PyChunkedArray, PyRecordBatch, PyRecordBatchReader, PyScalar, PyTable};
+
+#[cfg(feature = "arro3")]
+use crate::PyField;
 
 /// An enum over [PyRecordBatch] and [PyRecordBatchReader], used when a function accepts either
 /// Arrow object as input.
@@ -127,12 +132,14 @@ impl Datum for AnyDatum {
     }
 }
 
+#[cfg(feature = "arro3")]
 #[derive(FromPyObject)]
 pub(crate) enum MetadataInput {
     String(HashMap<String, String>),
     Bytes(HashMap<Vec<u8>, Vec<u8>>),
 }
 
+#[cfg(feature = "arro3")]
 impl MetadataInput {
     pub(crate) fn into_string_hashmap(self) -> PyResult<HashMap<String, String>> {
         match self {
@@ -149,18 +156,21 @@ impl MetadataInput {
     }
 }
 
+#[cfg(feature = "arro3")]
 impl Default for MetadataInput {
     fn default() -> Self {
         Self::String(Default::default())
     }
 }
 
+#[cfg(feature = "arro3")]
 #[derive(FromPyObject)]
 pub(crate) enum FieldIndexInput {
     Name(String),
     Position(usize),
 }
 
+#[cfg(feature = "arro3")]
 impl FieldIndexInput {
     /// This will additionally check that the input is valid against the given schema.
     ///
@@ -181,12 +191,14 @@ impl FieldIndexInput {
     }
 }
 
+#[cfg(feature = "arro3")]
 #[derive(FromPyObject)]
 pub(crate) enum NameOrField {
     Name(String),
     Field(PyField),
 }
 
+#[cfg(feature = "arro3")]
 impl NameOrField {
     pub fn into_field(self, source_field: &Field) -> FieldRef {
         match self {
@@ -203,12 +215,14 @@ impl NameOrField {
     }
 }
 
+#[cfg(feature = "arro3")]
 #[derive(FromPyObject)]
 pub(crate) enum SelectIndices {
     Names(Vec<String>),
     Positions(Vec<usize>),
 }
 
+#[cfg(feature = "arro3")]
 impl SelectIndices {
     pub fn into_positions(self, fields: &Fields) -> PyResult<Vec<usize>> {
         match self {

--- a/pyo3-arrow/src/interop/mod.rs
+++ b/pyo3-arrow/src/interop/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "arro3")]
 pub mod numpy;

--- a/pyo3-arrow/src/record_batch_reader.rs
+++ b/pyo3-arrow/src/record_batch_reader.rs
@@ -1,23 +1,31 @@
 use std::fmt::Display;
 use std::sync::{Arc, Mutex};
 
-use arrow_array::{ArrayRef, RecordBatchIterator, RecordBatchReader, StructArray};
+use arrow_array::{ArrayRef, RecordBatchReader, StructArray};
 use arrow_schema::{Field, SchemaRef};
-use pyo3::exceptions::{PyIOError, PyStopIteration, PyValueError};
+use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyCapsule, PyTuple, PyType};
+use pyo3::types::{PyCapsule, PyTuple};
 
 use crate::error::PyArrowResult;
-use crate::export::{Arro3RecordBatch, Arro3Schema, Arro3Table};
 use crate::ffi::from_python::utils::import_stream_pycapsule;
 use crate::ffi::to_python::chunked::ArrayIterator;
 use crate::ffi::to_python::nanoarrow::to_nanoarrow_array_stream;
 use crate::ffi::to_python::to_stream_pycapsule;
-use crate::ffi::to_schema_pycapsule;
-use crate::input::AnyRecordBatch;
 use crate::schema::display_schema;
-use crate::{PyRecordBatch, PySchema, PyTable};
+use crate::PyTable;
+
+#[cfg(feature = "arro3")]
+use {
+    crate::export::{Arro3RecordBatch, Arro3Schema, Arro3Table},
+    crate::ffi::to_schema_pycapsule,
+    crate::input::AnyRecordBatch,
+    crate::{PyRecordBatch, PySchema},
+    arrow_array::RecordBatchIterator,
+    pyo3::exceptions::PyStopIteration,
+    pyo3::types::PyType,
+};
 
 /// A Python-facing Arrow record batch reader.
 ///
@@ -85,57 +93,17 @@ impl PyRecordBatchReader {
         Ok(stream.schema())
     }
 
-    /// Export this to a Python `arro3.core.RecordBatchReader`.
-    pub fn to_arro3<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
-        arro3_mod
-            .getattr(intern!(py, "RecordBatchReader"))?
-            .call_method1(
-                intern!(py, "from_arrow_pycapsule"),
-                PyTuple::new(py, vec![self.__arrow_c_stream__(py, None)?])?,
-            )
-    }
-
-    /// Export this to a Python `arro3.core.RecordBatchReader`.
-    pub fn into_arro3(self, py: Python) -> PyResult<Bound<PyAny>> {
-        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+    pub(crate) fn to_stream_pycapsule<'py>(
+        &self,
+        py: Python<'py>,
+        requested_schema: Option<Bound<'py, PyCapsule>>,
+    ) -> PyArrowResult<Bound<'py, PyCapsule>> {
         let reader = self
             .0
             .lock()
             .unwrap()
             .take()
             .ok_or(PyIOError::new_err("Cannot read from closed stream"))?;
-        let capsule = Self::to_stream_pycapsule(py, reader, None)?;
-        arro3_mod
-            .getattr(intern!(py, "RecordBatchReader"))?
-            .call_method1(
-                intern!(py, "from_arrow_pycapsule"),
-                PyTuple::new(py, vec![capsule])?,
-            )
-    }
-
-    /// Export this to a Python `nanoarrow.ArrayStream`.
-    pub fn to_nanoarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        to_nanoarrow_array_stream(py, &self.__arrow_c_stream__(py, None)?)
-    }
-
-    /// Export to a pyarrow.RecordBatchReader
-    ///
-    /// Requires pyarrow >=15
-    pub fn into_pyarrow(self, py: Python) -> PyResult<Bound<PyAny>> {
-        let pyarrow_mod = py.import(intern!(py, "pyarrow"))?;
-        let record_batch_reader_class = pyarrow_mod.getattr(intern!(py, "RecordBatchReader"))?;
-        record_batch_reader_class.call_method1(
-            intern!(py, "from_stream"),
-            PyTuple::new(py, vec![self.into_pyobject(py)?])?,
-        )
-    }
-
-    pub(crate) fn to_stream_pycapsule<'py>(
-        py: Python<'py>,
-        reader: Box<dyn RecordBatchReader + Send>,
-        requested_schema: Option<Bound<'py, PyCapsule>>,
-    ) -> PyArrowResult<Bound<'py, PyCapsule>> {
         let schema = reader.schema().clone();
         let array_reader = reader.into_iter().map(|maybe_batch| {
             let arr: ArrayRef = Arc::new(StructArray::from(maybe_batch?));
@@ -148,6 +116,45 @@ impl PyRecordBatchReader {
                 .into(),
         ));
         to_stream_pycapsule(py, array_reader, requested_schema)
+    }
+
+    /// Export this to a Python `arro3.core.RecordBatchReader`.
+    pub fn to_arro3<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        arro3_mod
+            .getattr(intern!(py, "RecordBatchReader"))?
+            .call_method1(
+                intern!(py, "from_arrow_pycapsule"),
+                PyTuple::new(py, vec![self.to_stream_pycapsule(py, None)?])?,
+            )
+    }
+
+    /// Export this to a Python `arro3.core.RecordBatchReader`.
+    pub fn into_arro3(self, py: Python) -> PyResult<Bound<PyAny>> {
+        let arro3_mod = py.import(intern!(py, "arro3.core"))?;
+        arro3_mod
+            .getattr(intern!(py, "RecordBatchReader"))?
+            .call_method1(
+                intern!(py, "from_arrow_pycapsule"),
+                PyTuple::new(py, vec![self.to_stream_pycapsule(py, None)?])?,
+            )
+    }
+
+    /// Export this to a Python `nanoarrow.ArrayStream`.
+    pub fn to_nanoarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        to_nanoarrow_array_stream(py, &self.to_stream_pycapsule(py, None)?)
+    }
+
+    /// Export to a pyarrow.RecordBatchReader
+    ///
+    /// Requires pyarrow >=15
+    pub fn into_pyarrow(self, py: Python) -> PyResult<Bound<PyAny>> {
+        let pyarrow_mod = py.import(intern!(py, "pyarrow"))?;
+        let record_batch_reader_class = pyarrow_mod.getattr(intern!(py, "RecordBatchReader"))?;
+        record_batch_reader_class.call_method1(
+            intern!(py, "from_stream"),
+            PyTuple::new(py, vec![self.into_pyobject(py)?])?,
+        )
     }
 }
 
@@ -169,6 +176,7 @@ impl Display for PyRecordBatchReader {
     }
 }
 
+#[cfg(feature = "arro3")]
 #[pymethods]
 impl PyRecordBatchReader {
     fn __arrow_c_schema__<'py>(&'py self, py: Python<'py>) -> PyArrowResult<Bound<'py, PyCapsule>> {
@@ -181,13 +189,7 @@ impl PyRecordBatchReader {
         py: Python<'py>,
         requested_schema: Option<Bound<'py, PyCapsule>>,
     ) -> PyArrowResult<Bound<'py, PyCapsule>> {
-        let reader = self
-            .0
-            .lock()
-            .unwrap()
-            .take()
-            .ok_or(PyIOError::new_err("Cannot read from closed stream"))?;
-        Self::to_stream_pycapsule(py, reader, requested_schema)
+        self.to_stream_pycapsule(py, requested_schema)
     }
 
     // Return self


### PR DESCRIPTION
I gated all Python interface (`arro3-core`) specifics under the `arro3` Cargo feature. Basically, I hid all `#[pymethods]` and then refactored the Rust interface code that was using Python methods.

When I started this PR, I was hoping to reduce compilation time and extension library size for the users of `pyo3-arrow`, but it actually didn’t work well. Most of the gated crates are still transitive dependencies through `arrow-*` crates, which do not gate them over Cargo features. However, turning off `arro3` feature would remove seven dependencies. I benchmarked the changes with a test `maturin` project, which just implements a single method from the `pyo3-arrow` docs, and `maturin build --release` times reduced by 5–10%, while the wheel size changed by only 150 kB. I tried with default linking settings and with `lto = true; codegen-units = 1`, but the differences with and without the new `arro3` feature don’t depend on these settings.

I’ll let you decide if these changes are useful.

Fixes #477, fixes #395