### PR TITLE
ci: Use trusted publishing for pypi

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -261,12 +261,12 @@ jobs:
           - arro3-io
     name: Release
     environment:
-      name: release
+      name: pypi-release
       url: https://pypi.org/p/${{ matrix.module }}
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: [linux, musllinux, windows, macos]
     steps:
       - uses: actions/download-artifact@v4
@@ -278,7 +278,5 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
We had trusted publishing set up but weren't using it because we were still passing in a token and API key.