### PR TITLE
fix: Add missing writer.finish() call

### DIFF
--- a/arro3-io/src/json.rs
+++ b/arro3-io/src/json.rs
@@ -74,6 +74,7 @@ pub fn write_json(
     for batch in data.into_reader()? {
         writer.write(&batch?)?;
     }
+    writer.finish()?;
     Ok(())
 }
 

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -1,8 +1,9 @@
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pyarrow as pa
-from arro3.io import infer_json_schema, read_json, write_ndjson
+from arro3.io import infer_json_schema, read_json, write_json, write_ndjson
 
 
 def test_json_roundtrip():
@@ -16,3 +17,15 @@ def test_json_roundtrip():
 
         table_retour = pa.table(read_json(tmp_path / "test.json", schema))
         assert table == table_retour
+
+
+def test_json_read():
+    table = pa.table({"a": [1, 2, 3, 4]})
+    # We can't use tmp_path fixture with pytest-freethreading
+    with TemporaryDirectory() as tmp_path:
+        tmp_path = Path(tmp_path)
+        write_json(table, tmp_path / "test.json")
+
+        with tmp_path.joinpath("test.json").open("r") as f:
+            data = json.load(f)
+            assert data == [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}]

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pyarrow as pa
+from arro3.io import infer_json_schema, read_json, write_ndjson
+
+
+def test_json_roundtrip():
+    table = pa.table({"a": [1, 2, 3, 4]})
+    # We can't use tmp_path fixture with pytest-freethreading
+    with TemporaryDirectory() as tmp_path:
+        tmp_path = Path(tmp_path)
+        write_ndjson(table, tmp_path / "test.json")
+
+        schema = infer_json_schema(tmp_path / "test.json")
+
+        table_retour = pa.table(read_json(tmp_path / "test.json", schema))
+        assert table == table_retour


### PR DESCRIPTION
## Bugfix

This adds a single line to wrap up the output for `write_json`, which otherwise results in a missing closing array, `]`.

Fixes #496

### Additional issues

While writing the included test, I found that `read_json` and `infer_json_schema` does not work for JSON files written with `write_json`, but only works for files written with `write_ndjson`.

I added an additional test where I read it using the python `json` library, which works as expected.