### PR TITLE
ci: Fix publish of pyo3-arrow

### DIFF
--- a/.github/workflows/rust-release-pyo3-arrow.yml
+++ b/.github/workflows/rust-release-pyo3-arrow.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
-      - run: cargo publish -p pyo3-arrow
+      - run: cargo publish --manifest-path pyo3-arrow/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/pyo3-arrow/CHANGELOG.md
+++ b/pyo3-arrow/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 Release with pyo3 0.28 and arrow 59.
 
+- ci: Fix publish of pyo3-arrow #501
+
 ## [0.17.0] - 2026-02-25
 
 Release with pyo3 0.28 and arrow 58.


### PR DESCRIPTION
pyo3-arrow is not part of the workspace, so we can't use `-p`, which stands for `package` I think