### PR TITLE
ci: Add Windows ARM64 build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
           version: "0.9.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.13t 3.14t pypy3.11
+        run: uv python install 3.9 3.10 3.11 3.14t pypy3.11
 
       - name: Build abi3-py311 wheels
         uses: PyO3/maturin-action@v1
@@ -78,7 +78,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           # As of Nov 2024, it was necessary to manually specify -i 3.13 to get
           # maturin to find the executable. --find-interpreter did not find it.
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.13t -i 3.14t -i pypy3.11 --manifest-path ${{ matrix.module }}/Cargo.toml
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.14t -i pypy3.11 --manifest-path ${{ matrix.module }}/Cargo.toml
           sccache: "true"
           manylinux: ${{ matrix.platform.manylinux }}
 
@@ -116,7 +116,7 @@ jobs:
           version: "0.9.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.13t 3.14t pypy3.11
+        run: uv python install 3.9 3.10 3.11 3.14t pypy3.11
 
       - name: Build abi3-py311 wheels
         uses: PyO3/maturin-action@v1
@@ -132,7 +132,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           # As of Nov 2024, it was necessary to manually specify -i 3.13 to get
           # maturin to find the executable. --find-interpreter did not find it.
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.13t -i 3.14t -i pypy3.11 --manifest-path ${{ matrix.module }}/Cargo.toml
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.14t -i pypy3.11 --manifest-path ${{ matrix.module }}/Cargo.toml
           sccache: "true"
           manylinux: musllinux_1_2
 
@@ -167,7 +167,6 @@ jobs:
           python-version: |
             ${{ join(matrix.platform.extra-interpreters, fromJSON('"\n"')) }}
             3.11
-            3.13t
             3.14t
 
       - name: Build abi3-py311 wheels
@@ -183,7 +182,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           # As of Nov 2024, it was necessary to manually specify -i 3.13 to get
           # maturin to find the executable. --find-interpreter did not find it.
-          args: --release --out dist -i ${{ join(matrix.platform.extra-interpreters, ' ') }} 3.13t 3.14t --manifest-path ${{ matrix.module }}/Cargo.toml
+          args: --release --out dist -i ${{ join(matrix.platform.extra-interpreters, ' ') }} 3.14t --manifest-path ${{ matrix.module }}/Cargo.toml
           sccache: "true"
 
       - name: Upload wheels
@@ -216,7 +215,7 @@ jobs:
           version: "0.9.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.13t 3.14t pypy3.11
+        run: uv python install 3.9 3.10 3.11 3.14t pypy3.11
 
       - name: Build abi3-py311 wheels
         uses: PyO3/maturin-action@v1
@@ -231,7 +230,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           # As of Nov 2024, it was necessary to manually specify -i 3.13 to get
           # maturin to find the executable. --find-interpreter did not find it.
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.13t -i 3.14t -i pypy3.11 --manifest-path ${{ matrix.module }}/Cargo.toml
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.14t -i pypy3.11 --manifest-path ${{ matrix.module }}/Cargo.toml
           sccache: "true"
 
       - name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -150,6 +150,11 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
+            # setup-python has no Windows arm64 builds before 3.11.
+            extra-interpreters: ["3.9", "3.10"]
+          - runner: windows-11-arm
+            target: aarch64
+            extra-interpreters: []
         module:
           - arro3-core
           - arro3-compute
@@ -160,8 +165,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: |
-            3.9
-            3.10
+            ${{ join(matrix.platform.extra-interpreters, fromJSON('"\n"')) }}
             3.11
             3.13t
             3.14t
@@ -179,7 +183,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           # As of Nov 2024, it was necessary to manually specify -i 3.13 to get
           # maturin to find the executable. --find-interpreter did not find it.
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.13t -i 3.14t --manifest-path ${{ matrix.module }}/Cargo.toml
+          args: --release --out dist -i ${{ join(matrix.platform.extra-interpreters, ' ') }} 3.13t 3.14t --manifest-path ${{ matrix.module }}/Cargo.toml
           sccache: "true"
 
       - name: Upload wheels


### PR DESCRIPTION
As the title says.

Windows ARM64 only has Python 3.11+ in both the official CPython releases and the setup-python action, so builds target those versions.

Additionally, all of the Linux/macOS/Windows builds were failing because [maturin dropped support for 3.13t](https://github.com/PyO3/maturin/pull/3113/changes#diff-1fc8eaba4ee1068e1575f5de44acda74707694f599bea00b8bd5c17bd4e43629). So I have removed 3.13t from all builds -- let me know if you would prefer a different approach instead.